### PR TITLE
Fix issue #28

### DIFF
--- a/examples/basic-example-sb-3/src/main/java/io/github/acoboh/query/filter/example/controllers/PostRestController.java
+++ b/examples/basic-example-sb-3/src/main/java/io/github/acoboh/query/filter/example/controllers/PostRestController.java
@@ -27,7 +27,7 @@ public class PostRestController {
 
 	@GetMapping
 	public Page<PostDTO> getPosts(
-			@QFParam(PostFilterDef.class) @RequestParam(required = false, defaultValue = "") QueryFilter<PostBlog> filter,
+			@QFParam(PostFilterDef.class) @RequestParam(required = false, defaultValue = "", name = "filter") QueryFilter<PostBlog> filter,
 			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
 		return service.getPosts(filter, page, size);
 	}

--- a/examples/basic-example/src/main/java/io/github/acoboh/query/filter/example/controllers/PostRestController.java
+++ b/examples/basic-example/src/main/java/io/github/acoboh/query/filter/example/controllers/PostRestController.java
@@ -27,7 +27,7 @@ public class PostRestController {
 
 	@GetMapping
 	public Page<PostDTO> getPosts(
-			@QFParam(PostFilterDef.class) @RequestParam(required = false, defaultValue = "") QueryFilter<PostBlog> filter,
+			@QFParam(PostFilterDef.class) @RequestParam(required = false, defaultValue = "", name = "filter") QueryFilter<PostBlog> filter,
 			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
 		return service.getPosts(filter, page, size);
 	}

--- a/query-filter-jpa-openapi-3/src/main/java/io/github/acoboh/query/filter/jpa/openapi/config/OpenApiCustomiserImpl.java
+++ b/query-filter-jpa-openapi-3/src/main/java/io/github/acoboh/query/filter/jpa/openapi/config/OpenApiCustomiserImpl.java
@@ -19,6 +19,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import io.github.acoboh.query.filter.jpa.annotations.QFDiscriminator;
@@ -107,8 +108,18 @@ class OpenApiCustomiserImpl implements OpenApiCustomizer {
 						Operation op = getOperation(optPath.get(),
 								requestMapping.getKey().getMethodsCondition().getMethods().iterator().next());
 
+						String paramName = param.getName();
+						if (param.isAnnotationPresent(RequestParam.class)) {
+							RequestParam requestParam = param.getAnnotation(RequestParam.class);
+							if (!requestParam.name().isEmpty()) {
+								paramName = requestParam.name();
+							}
+						}
+
+						final String finalParamName = paramName;
+
 						Optional<io.swagger.v3.oas.models.parameters.Parameter> optParam = op.getParameters().stream()
-								.filter(e -> e.getName().equals("filter")).findFirst();
+								.filter(e -> e.getName().equals(finalParamName)).findFirst();
 
 						if (optParam.isEmpty()) {
 							LOGGER.error("Error getting parameter filter on path {}", path);

--- a/query-filter-jpa-openapi/src/main/java/io/github/acoboh/query/filter/jpa/openapi/config/OpenApiCustomiserImpl.java
+++ b/query-filter-jpa-openapi/src/main/java/io/github/acoboh/query/filter/jpa/openapi/config/OpenApiCustomiserImpl.java
@@ -21,6 +21,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -111,8 +112,18 @@ class OpenApiCustomiserImpl implements OpenApiCustomiser {
 						Operation op = getOperation(optPath.get(),
 								requestMapping.getKey().getMethodsCondition().getMethods().iterator().next());
 
+						String paramName = param.getName();
+						if (param.isAnnotationPresent(RequestParam.class)) {
+							RequestParam requestParam = param.getAnnotation(RequestParam.class);
+							if (!requestParam.name().isEmpty()) {
+								paramName = requestParam.name();
+							}
+						}
+
+						final String finalParamName = paramName;
+
 						Optional<io.swagger.v3.oas.models.parameters.Parameter> optParam = op.getParameters().stream()
-								.filter(e -> e.getName().equals("filter")).findFirst();
+								.filter(e -> e.getName().equals(finalParamName)).findFirst();
 
 						if (!optParam.isPresent()) {
 							LOGGER.error("Error getting parameter filter on path {}", path);


### PR DESCRIPTION
Fixed issue with param names on RequestParam fields on controller methods.

Now use the `name` from the argument if it has the `@RequestParam` annotation. If the function doesn't have it or the `name` parameter is empty, it will use the argument's name.

**_NOTE_**: By default, if the code is not compiled with the `-parameters` argument, the arguments will take the form of `argN` and cannot be used. It is recommended to always use the `name` parameter of the `@RequestParam` annotation.