### PR TITLE
Subpath mapping. Fixed discriminators with subpath

### DIFF
--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFCollectionElement.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFCollectionElement.java
@@ -32,4 +32,46 @@ public @interface QFCollectionElement {
 	 * @return name
 	 */
 	String name() default "";
+
+	/**
+	 * Select the class of the element if it is only available on a nested Discriminator class.
+	 * <p>
+	 * Example: <blockquote>
+	 * 
+	 * <pre>
+	 * &#64;Entity
+	 * &#64;Inheritance(strategy = InheritanceType.JOINED)
+	 * public class ParentEntity {
+	 *     // Base data
+	 * }
+	 * 
+	 * &#64;Entity
+	 * public class SubclassAEntity extends ParentEntity {
+	 *     // Subclass A data
+	 *     &#64;OneToMany
+	 *     private List links;
+	 * }
+	 * 
+	 * &#64;QFDefinitionClass(ParentEntity.class)
+	 * public class FilterParentEntityDef {
+	 *    &#64;QFCollectionElement(value = "links", subClassMapping = SubclassAEntity.class)
+	 *    private int links;
+	 * }
+	 * }
+	 * </pre>
+	 * 
+	 * </blockquote>
+	 * 
+	 * @return subClassMapping
+	 */
+	Class<?> subClassMapping() default Void.class;
+
+	/**
+	 * Select the path of the subclass level if it is only available on a nested Discriminator class.
+	 * <p>
+	 * Need to be used with {@linkplain #subClassMapping()}
+	 * 
+	 * @return path to apply subclass scanning
+	 */
+	String subClassMappingPath() default "";
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFElement.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFElement.java
@@ -146,4 +146,44 @@ public @interface QFElement {
 	 */
 	boolean autoFetch() default true;
 
+	/**
+	 * Select the class of the element if it is only available on a nested Discriminator class.
+	 * <p>
+	 * Example: <blockquote>
+	 * 
+	 * <pre>
+	 * {@code @Entity }
+	 * {@code @Inheritance(strategy = InheritanceType.JOINED)}
+	 * public class ParentEntity {
+	 *     // Base data
+	 * }
+	 * 
+	 * {@code @Entity }
+	 * public class SubclassAEntity extends ParentEntity {
+	 *     // Subclass A data
+	 *     private String subClassField;
+	 * }
+	 * 
+	 * {@code @QFDefinitionClass(ParentEntity.class)}
+	 * public class FilterParentEntityDef {
+	 *    {@code @QFElement(value = "subClassField", subClassMapping = SubclassAEntity.class)}
+	 *    private String subClassField;
+	 * {@code}}
+	 * </pre>
+	 * 
+	 * </blockquote>
+	 * 
+	 * @return subClassMapping
+	 */
+	Class<?> subClassMapping() default Void.class;
+
+	/**
+	 * Select the path of the subclass level if it is only available on a nested Discriminator class.
+	 * <p>
+	 * Need to be used with {@linkplain #subClassMapping()}
+	 * 
+	 * @return path to apply subclass scanning
+	 */
+	String subClassMappingPath() default "";
+
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/config/QFBeanFactoryPostProcessor.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/config/QFBeanFactoryPostProcessor.java
@@ -33,7 +33,6 @@ import org.springframework.util.Assert;
 
 import io.github.acoboh.query.filter.jpa.annotations.EnableQueryFilter;
 import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
-import io.github.acoboh.query.filter.jpa.exceptions.QueryFilterException;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
 import io.github.acoboh.query.filter.jpa.processor.QFProcessor;
 
@@ -169,7 +168,7 @@ public class QFBeanFactoryPostProcessor implements ApplicationContextAware, Bean
 				QFProcessor<?, ?> qfp = registerQueryFilterClass(cl, beanFactory);
 				mapProcessors.put(cl, qfp);
 			} catch (QueryFilterDefinitionException e) {
-				throw new BeanCreationException("Error creating bean query filter", e);
+				throw new BeanCreationException("Error creating bean query filter for class " + cl.getName(), e);
 			}
 		}
 
@@ -200,8 +199,9 @@ public class QFBeanFactoryPostProcessor implements ApplicationContextAware, Bean
 			QFProcessor<?, ?> ret = new QFProcessor<>(cl, annotationClass.value(), applicationContext);
 			bf.registerSingleton(beanName, ret);
 			return ret;
-		} catch (QueryFilterException e) {
-			LOGGER.error("Error registering bean query filter of class {}", cl);
+		} catch (QueryFilterDefinitionException e) {
+			LOGGER.error("Error registering bean query filter of class {} for entity class {}", cl,
+					annotationClass.value());
 			throw e;
 		}
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QFPath.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QFPath.java
@@ -50,6 +50,8 @@ public class QFPath {
 
 	private boolean isFinal;
 
+	private final Class<?> treatClass;
+
 	/**
 	 * Default constructor
 	 *
@@ -58,13 +60,16 @@ public class QFPath {
 	 * @param path       path
 	 * @param fieldClass field class
 	 * @param isFinal    if the field is final
+	 * @param treatClass treat class
 	 */
-	public QFPath(Field field, String path, QFElementDefType type, Class<?> fieldClass, boolean isFinal) {
+	public QFPath(Field field, String path, QFElementDefType type, Class<?> fieldClass, boolean isFinal,
+			Class<?> treatClass) {
 		this.type = type;
 		this.field = field;
 		this.path = path;
 		this.fieldClass = fieldClass;
 		this.isFinal = isFinal;
+		this.treatClass = treatClass;
 	}
 
 	/**
@@ -139,4 +144,25 @@ public class QFPath {
 		return path;
 	}
 
+	/**
+	 * Get path name for map with treat class
+	 * 
+	 * @return path name
+	 */
+	public String getPathName() {
+		if (treatClass != null && !Void.class.equals(treatClass)) {
+			return path + "-asTreat-" + treatClass.getSimpleName();
+		}
+
+		return path;
+	}
+
+	/**
+	 * Get treat class
+	 * 
+	 * @return null if not set
+	 */
+	public Class<?> getTreatClass() {
+		return treatClass;
+	}
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QueryFilter.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QueryFilter.java
@@ -212,7 +212,9 @@ public class QueryFilter<E> implements Specification<E> {
 
 		Matcher matcher = REGEX_PATTERN.matcher(values);
 
+		boolean match = false;
 		while (matcher.find()) {
+			match = true;
 
 			String order = matcher.group(1);
 			String fieldName = matcher.group(2);
@@ -222,7 +224,7 @@ public class QueryFilter<E> implements Specification<E> {
 				throw new QFFieldNotFoundException(fieldName);
 			}
 
-			if (!(def instanceof IDefinitionSortable)) {
+			if (!(def instanceof IDefinitionSortable idef) || !idef.isSortable()) {
 				throw new QFNotSortableException(fieldName);
 			}
 
@@ -231,16 +233,20 @@ public class QueryFilter<E> implements Specification<E> {
 			}
 
 			Direction dir;
-			if (order.equals("+")) {
-				dir = Direction.ASC;
-			} else {
+			if (order.equals("-")) {
 				dir = Direction.DESC;
+			} else {
+				dir = Direction.ASC;
 			}
 
 			Pair<IDefinitionSortable, Direction> pair = Pair.of((IDefinitionSortable) def, dir);
 			this.sortDefinitionList.add(pair);
 			this.defaultSortEnabled = false;
 
+		}
+
+		if (!match) {
+			throw new QFParseException(values, initialInput);
 		}
 
 	}
@@ -400,7 +406,7 @@ public class QueryFilter<E> implements Specification<E> {
 			throw new QFFieldNotFoundException(field);
 		}
 
-		if (!(def instanceof IDefinitionSortable)) {
+		if (!(def instanceof IDefinitionSortable idef) || !idef.isSortable()) {
 			throw new QFNotSortableException(field);
 		}
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
@@ -25,8 +25,8 @@ public class QFDefinitionCollection extends QFAbstractDefinition {
 			QFCollectionElement collectionElement) throws QueryFilterDefinitionException {
 		super(filterField, filterClass, entityClass, blockParsing);
 
-		// TODO Fix
-		var fieldClassProcessor = new FieldClassProcessor(entityClass, collectionElement.value(), false, null, null);
+		var fieldClassProcessor = new FieldClassProcessor(entityClass, collectionElement.value(), false,
+				collectionElement.subClassMapping(), collectionElement.subClassMappingPath());
 
 		this.paths = fieldClassProcessor.getPaths();
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
@@ -25,7 +25,8 @@ public class QFDefinitionCollection extends QFAbstractDefinition {
 			QFCollectionElement collectionElement) throws QueryFilterDefinitionException {
 		super(filterField, filterClass, entityClass, blockParsing);
 
-		var fieldClassProcessor = new FieldClassProcessor(entityClass, collectionElement.value(), false);
+		// TODO Fix
+		var fieldClassProcessor = new FieldClassProcessor(entityClass, collectionElement.value(), false, null, null);
 
 		this.paths = fieldClassProcessor.getPaths();
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
@@ -2,10 +2,13 @@ package io.github.acoboh.query.filter.jpa.processor.definitions;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import io.github.acoboh.query.filter.jpa.annotations.QFBlockParsing;
 import io.github.acoboh.query.filter.jpa.annotations.QFDiscriminator;
+import io.github.acoboh.query.filter.jpa.exceptions.definition.QFDiscriminatorException;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
 import io.github.acoboh.query.filter.jpa.processor.QFPath;
 
@@ -16,6 +19,9 @@ public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 
 	private final QFDiscriminator discriminatorAnnotation;
 	private final List<QFPath> paths;
+	private final Class<?> finalClass;
+
+	private Map<String, Class<?>> discriminatorMap = new HashMap<>();
 
 	QFDefinitionDiscriminator(Field filterField, Class<?> filterClass, Class<?> entityClass,
 			QFBlockParsing blockParsing, QFDiscriminator discriminatorAnnotation)
@@ -25,14 +31,31 @@ public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 		this.discriminatorAnnotation = discriminatorAnnotation;
 
 		if (!discriminatorAnnotation.path().isEmpty()) {
-			var fieldClassProcessor = new FieldClassProcessor(entityClass, discriminatorAnnotation.path(), true);
+			// TODO Fix
+			var fieldClassProcessor = new FieldClassProcessor(entityClass, discriminatorAnnotation.path(), false, null,
+					null);
 			this.paths = fieldClassProcessor.getPaths();
+			this.finalClass = fieldClassProcessor.getFinalClass();
 		} else {
 			this.paths = Collections.emptyList();
+			this.finalClass = entityClass;
 		}
 
 		if (!discriminatorAnnotation.name().isEmpty()) {
 			super.filterName = discriminatorAnnotation.name();
+		}
+
+		for (var value : discriminatorAnnotation.value()) {
+			if (discriminatorMap.containsKey(value.name())) {
+				throw new QFDiscriminatorException("Duplicate discriminator value name {}", value.name());
+			}
+
+			if (!finalClass.isAssignableFrom(value.type())) {
+				throw new QFDiscriminatorException("Entity class '{}' is not assignable from value class '{}'",
+						finalClass, value.type());
+			}
+
+			discriminatorMap.put(value.name(), value.type());
 		}
 
 	}
@@ -53,6 +76,24 @@ public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 	 */
 	public List<QFPath> getPaths() {
 		return paths;
+	}
+
+	/**
+	 * Get final entity class
+	 * 
+	 * @return final entity class
+	 */
+	public Class<?> getFinalClass() {
+		return finalClass;
+	}
+
+	/**
+	 * Get the discriminator map
+	 * 
+	 * @return discriminator map
+	 */
+	public Map<String, Class<?>> getDiscriminatorMap() {
+		return discriminatorMap;
 	}
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
@@ -31,7 +31,6 @@ public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 		this.discriminatorAnnotation = discriminatorAnnotation;
 
 		if (!discriminatorAnnotation.path().isEmpty()) {
-			// TODO Fix
 			var fieldClassProcessor = new FieldClassProcessor(entityClass, discriminatorAnnotation.path(), false, null,
 					null);
 			this.paths = fieldClassProcessor.getPaths();

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionElement.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionElement.java
@@ -122,7 +122,8 @@ public final class QFDefinitionElement extends QFAbstractDefinition implements I
 
 		for (QFElement elem : elementAnnotations) {
 			LOGGER.trace("Creating paths for element annotation {}", elem);
-			var fieldClassProcessor = new FieldClassProcessor(entityClass, elem.value(), true);
+			var fieldClassProcessor = new FieldClassProcessor(entityClass, elem.value(), true, elem.subClassMapping(),
+					elem.subClassMappingPath());
 
 			List<QFPath> path = fieldClassProcessor.getPaths();
 			paths.add(path);

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
@@ -28,7 +28,8 @@ public class QFDefinitionJson extends QFAbstractDefinition {
 			super.filterName = jsonAnnotation.name();
 		}
 
-		var fieldClassProcessor = new FieldClassProcessor(entityClass, jsonAnnotation.value(), false);
+		// TODO Fix
+		var fieldClassProcessor = new FieldClassProcessor(entityClass, jsonAnnotation.value(), false, null, null);
 
 		this.paths = fieldClassProcessor.getPaths();
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
@@ -28,7 +28,6 @@ public class QFDefinitionJson extends QFAbstractDefinition {
 			super.filterName = jsonAnnotation.name();
 		}
 
-		// TODO Fix
 		var fieldClassProcessor = new FieldClassProcessor(entityClass, jsonAnnotation.value(), false, null, null);
 
 		this.paths = fieldClassProcessor.getPaths();

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
@@ -28,8 +28,9 @@ public class QFDefinitionSortable extends QFAbstractDefinition implements IDefin
 
 		paths = new ArrayList<>(1); // Only one path
 
+		// TODO Fix
 		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, sortableAnnotation.value(),
-				true);
+				true, null, null);
 		paths.add(fieldClassProcessor.getPaths());
 
 		autoFetch = sortableAnnotation.autoFetch();

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
@@ -28,9 +28,8 @@ public class QFDefinitionSortable extends QFAbstractDefinition implements IDefin
 
 		paths = new ArrayList<>(1); // Only one path
 
-		// TODO Fix
-		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, sortableAnnotation.value(),
-				true, null, null);
+		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, sortableAnnotation.value(), true,
+				null, null);
 		paths.add(fieldClassProcessor.getPaths());
 
 		autoFetch = sortableAnnotation.autoFetch();

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFCollectionMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFCollectionMatch.java
@@ -80,7 +80,8 @@ public class QFCollectionMatch implements QFSpecificationPart {
 			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
 			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass) {
 
-		Path<?> expressionPath = QueryUtils.getObject(root, definition.getPaths(), pathsMap, true, false);
+		Path<?> expressionPath = QueryUtils.getObject(root, definition.getPaths(), pathsMap, true, false,
+				criteriaBuilder);
 
 		Expression<? extends java.util.Collection<?>> expression;
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFElementMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFElementMatch.java
@@ -456,8 +456,9 @@ public class QFElementMatch implements QFSpecificationPart {
 		List<Predicate> predicates = new ArrayList<>();
 
 		for (List<QFPath> path : paths) {
-			predicates.add(operation.generatePredicate(QueryUtils.getObject(root, path, pathsMap, false, false),
-					criteriaBuilder, this, index, mlmap));
+			predicates.add(operation.generatePredicate(
+					QueryUtils.getObject(root, path, pathsMap, false, false, criteriaBuilder), criteriaBuilder, this,
+					index, mlmap));
 			index++;
 		}
 
@@ -485,7 +486,7 @@ public class QFElementMatch implements QFSpecificationPart {
 
 			subquery.select(newRoot);
 
-			Path<?> pathFinal = QueryUtils.getObject(newRoot, path, subSelecthMap, false, false);
+			Path<?> pathFinal = QueryUtils.getObject(newRoot, path, subSelecthMap, false, false, criteriaBuilder);
 
 			QFOperationEnum op = operation;
 			if (op == QFOperationEnum.NOT_EQUAL) {

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFJsonElementMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFJsonElementMatch.java
@@ -165,8 +165,8 @@ public class QFJsonElementMatch implements QFSpecificationPart {
 
 		predicatesMap.computeIfAbsent(definition.getFilterName(), t -> new ArrayList<>())
 				.add(operation.generateJsonPredicate(
-						QueryUtils.getObject(root, definition.getPaths(), pathsMap, true, false), criteriaBuilder,
-						this));
+						QueryUtils.getObject(root, definition.getPaths(), pathsMap, true, false, criteriaBuilder),
+						criteriaBuilder, this));
 
 	}
 

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterParentEntityDef.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterParentEntityDef.java
@@ -1,0 +1,27 @@
+package io.github.acoboh.query.filter.jpa.domain;
+
+import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
+import io.github.acoboh.query.filter.jpa.annotations.QFDiscriminator;
+import io.github.acoboh.query.filter.jpa.annotations.QFElement;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity.TypeEnum;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassAEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassBEntity;
+
+/**
+ * Parent entity discriminators filter class
+ */
+@QFDefinitionClass(ParentEntity.class)
+public class FilterParentEntityDef {
+
+	@QFElement("type")
+	private TypeEnum type;
+
+	@QFDiscriminator({ @QFDiscriminator.Value(name = "subclassA", type = SubclassAEntity.class),
+			@QFDiscriminator.Value(name = "subclassB", type = SubclassBEntity.class) })
+	private String discriminatorType;
+
+	@QFElement(value = "subClassField", subClassMapping = SubclassAEntity.class)
+	private String subClassAField;
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterRelatedParentEntityDef.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterRelatedParentEntityDef.java
@@ -1,0 +1,28 @@
+package io.github.acoboh.query.filter.jpa.domain;
+
+import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
+import io.github.acoboh.query.filter.jpa.annotations.QFDiscriminator;
+import io.github.acoboh.query.filter.jpa.annotations.QFElement;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity.TypeEnum;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.RelatedParent;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassAEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassBEntity;
+
+/**
+ * Parent entity discriminators filter class
+ */
+@QFDefinitionClass(RelatedParent.class)
+public class FilterRelatedParentEntityDef {
+
+	@QFElement("parent.type")
+	private TypeEnum type;
+
+	@QFDiscriminator(path = "parent", value = {
+			@QFDiscriminator.Value(name = "subclassA", type = SubclassAEntity.class),
+			@QFDiscriminator.Value(name = "subclassB", type = SubclassBEntity.class) })
+	private String discriminatorType;
+
+	@QFElement(value = "parent.subClassField", subClassMapping = SubclassAEntity.class, subClassMappingPath = "parent")
+	private String subClassAField;
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/ParentEntity.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/ParentEntity.java
@@ -1,0 +1,109 @@
+package io.github.acoboh.query.filter.jpa.model.discriminators.joined;
+
+import java.util.Objects;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+
+/**
+ * Parent entity
+ */
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+public abstract class ParentEntity {
+
+	/**
+	 * Type enum
+	 */
+	public enum TypeEnum {
+		/**
+		 * A type
+		 */
+		A,
+		/**
+		 * B type
+		 */
+		B
+	}
+
+	@Id
+	private String id;
+
+	private TypeEnum type;
+
+	private boolean active = false;
+
+	/**
+	 * Get the id
+	 * 
+	 * @return the id
+	 */
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * Set the id
+	 * 
+	 * @param id
+	 */
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	/**
+	 * Get the type
+	 * 
+	 * @return the type
+	 */
+	public TypeEnum getType() {
+		return type;
+	}
+
+	/**
+	 * Set the type
+	 * 
+	 * @param type
+	 */
+	public void setType(TypeEnum type) {
+		this.type = type;
+	}
+
+	/**
+	 * Get the active
+	 * 
+	 * @return the active
+	 */
+	public boolean isActive() {
+		return active;
+	}
+
+	/**
+	 * Set the active
+	 * 
+	 * @param active
+	 */
+	public void setActive(boolean active) {
+		this.active = active;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(active, id, type);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ParentEntity other = (ParentEntity) obj;
+		return active == other.active && Objects.equals(id, other.id) && type == other.type;
+	}
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/RelatedParent.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/RelatedParent.java
@@ -1,0 +1,76 @@
+package io.github.acoboh.query.filter.jpa.model.discriminators.joined;
+
+import java.util.Objects;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+/**
+ * Related parent entity
+ */
+@Entity
+public class RelatedParent {
+
+	@Id
+	private String id;
+
+	@ManyToOne
+	@JoinColumn(name = "parent_id")
+	private ParentEntity parent;
+
+	/**
+	 * Get the id
+	 * 
+	 * @return the id
+	 */
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * Set the id
+	 * 
+	 * @param id
+	 */
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	/**
+	 * Get the parent
+	 * 
+	 * @return the parent
+	 */
+	public ParentEntity getParent() {
+		return parent;
+	}
+
+	/**
+	 * Set the parent
+	 * 
+	 * @param parent
+	 */
+	public void setParent(ParentEntity parent) {
+		this.parent = parent;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, parent);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		RelatedParent other = (RelatedParent) obj;
+		return Objects.equals(id, other.id) && Objects.equals(parent, other.parent);
+	}
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/SubclassAEntity.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/SubclassAEntity.java
@@ -1,0 +1,73 @@
+package io.github.acoboh.query.filter.jpa.model.discriminators.joined;
+
+import java.util.Objects;
+
+import jakarta.persistence.Entity;
+
+/**
+ * Subclass A entity
+ */
+@Entity
+public class SubclassAEntity extends ParentEntity {
+
+	private String subClassField;
+
+	private boolean flag;
+
+	/**
+	 * Get the sub class field
+	 * 
+	 * @return the sub class field
+	 */
+	public String getSubClassField() {
+		return subClassField;
+	}
+
+	/**
+	 * Set the subclass field
+	 * 
+	 * @param subClassField
+	 */
+	public void setSubClassField(String subClassField) {
+		this.subClassField = subClassField;
+	}
+
+	/**
+	 * Get the flag
+	 * 
+	 * @return the flag
+	 */
+	public boolean isFlag() {
+		return flag;
+	}
+
+	/**
+	 * Set the flag
+	 * 
+	 * @param flag
+	 */
+	public void setFlag(boolean flag) {
+		this.flag = flag;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + Objects.hash(flag, subClassField);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SubclassAEntity other = (SubclassAEntity) obj;
+		return flag == other.flag && Objects.equals(subClassField, other.subClassField);
+	}
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/SubclassBEntity.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/SubclassBEntity.java
@@ -1,0 +1,53 @@
+package io.github.acoboh.query.filter.jpa.model.discriminators.joined;
+
+import java.util.Objects;
+
+import jakarta.persistence.Entity;
+
+/**
+ * Subclass B entity
+ */
+@Entity
+public class SubclassBEntity extends ParentEntity {
+
+	private String text;
+
+	/**
+	 * Get the text
+	 * 
+	 * @return the text
+	 */
+	public String getText() {
+		return text;
+	}
+
+	/**
+	 * Set the text
+	 * 
+	 * @param text
+	 */
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + Objects.hash(text);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SubclassBEntity other = (SubclassBEntity) obj;
+		return Objects.equals(text, other.text);
+	}
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/DiscriminatorJoinTest.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/DiscriminatorJoinTest.java
@@ -1,0 +1,198 @@
+package io.github.acoboh.query.filter.jpa.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import io.github.acoboh.query.filter.jpa.domain.FilterParentEntityDef;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity.TypeEnum;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassAEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassBEntity;
+import io.github.acoboh.query.filter.jpa.repositories.ParentEntityRepository;
+import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
+
+/**
+ * Discriminator join tests
+ */
+@SpringJUnitWebConfig(SpringIntegrationTestBase.Config.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DiscriminatorJoinTest {
+
+	private static final SubclassAEntity SUBCLASS_A_EXAMPLE = new SubclassAEntity();
+	private static final SubclassAEntity SUBCLASS_A_EXAMPLE_2 = new SubclassAEntity();
+
+	private static final SubclassBEntity SUBCLASS_B_EXAMPLE = new SubclassBEntity();
+	private static final SubclassBEntity SUBCLASS_B_EXAMPLE_2 = new SubclassBEntity();
+
+	static {
+		SUBCLASS_A_EXAMPLE.setId("1");
+		SUBCLASS_A_EXAMPLE.setActive(true);
+		SUBCLASS_A_EXAMPLE.setType(TypeEnum.A);
+		SUBCLASS_A_EXAMPLE.setSubClassField("Subclass A field");
+		SUBCLASS_A_EXAMPLE.setFlag(true);
+
+		SUBCLASS_A_EXAMPLE_2.setId("2");
+		SUBCLASS_A_EXAMPLE_2.setActive(false);
+		SUBCLASS_A_EXAMPLE_2.setType(TypeEnum.A);
+		SUBCLASS_A_EXAMPLE_2.setSubClassField("Subclass A field 2");
+		SUBCLASS_A_EXAMPLE_2.setFlag(false);
+
+		SUBCLASS_B_EXAMPLE.setId("3");
+		SUBCLASS_B_EXAMPLE.setActive(true);
+		SUBCLASS_B_EXAMPLE.setType(TypeEnum.B);
+		SUBCLASS_B_EXAMPLE.setText("Subclass B text");
+
+		SUBCLASS_B_EXAMPLE_2.setId("4");
+		SUBCLASS_B_EXAMPLE_2.setActive(false);
+		SUBCLASS_B_EXAMPLE_2.setType(TypeEnum.B);
+		SUBCLASS_B_EXAMPLE_2.setText("Subclass B text 2");
+
+	}
+
+	@Autowired
+	private QFProcessor<FilterParentEntityDef, ParentEntity> queryFilterProcessor;
+
+	@Autowired
+	private ParentEntityRepository repository;
+
+	@Test
+	@DisplayName("0. Setup")
+	@Order(0)
+	void setup() {
+
+		assertThat(queryFilterProcessor).isNotNull();
+		assertThat(repository).isNotNull();
+
+		assertThat(repository.findAll()).isEmpty();
+
+		repository.save(SUBCLASS_A_EXAMPLE);
+		repository.save(SUBCLASS_A_EXAMPLE_2);
+		repository.save(SUBCLASS_B_EXAMPLE);
+		repository.save(SUBCLASS_B_EXAMPLE_2);
+		repository.flush();
+
+		assertThat(repository.findAll()).hasSize(4).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE, SUBCLASS_A_EXAMPLE_2,
+				SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2);
+
+	}
+
+	@Test
+	@DisplayName("1. Filter by parent class")
+	@Order(1)
+	void filterByParentClass() {
+
+		QueryFilter<ParentEntity> qf = queryFilterProcessor.newQueryFilter("type=eq:A", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<ParentEntity> list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE, SUBCLASS_A_EXAMPLE_2);
+
+		qf = queryFilterProcessor.newQueryFilter("type=eq:B", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactlyInAnyOrder(SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2);
+
+	}
+
+	@Test
+	@DisplayName("2. Filter by discriminator class")
+	@Order(2)
+	void filterByDiscriminatorClass() {
+
+		QueryFilter<ParentEntity> qf = queryFilterProcessor.newQueryFilter("discriminatorType=eq:subclassA",
+				QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<ParentEntity> list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE, SUBCLASS_A_EXAMPLE_2);
+
+		qf = queryFilterProcessor.newQueryFilter("discriminatorType=eq:subclassB", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactlyInAnyOrder(SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2);
+
+	}
+
+	@Test
+	@DisplayName("3. Filter by subclass a field")
+	@Order(3)
+	void filterBySubclassAField() {
+
+		// On Hibernate 6, the filter will apply a Left Join on the subclassA table and all data from SubclassB will be returned matching
+		// the criteria query
+
+		QueryFilter<ParentEntity> qf = queryFilterProcessor.newQueryFilter("subClassAField=eq:Subclass A field",
+				QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<ParentEntity> list = repository.findAll(qf);
+		assertThat(list).hasSize(1).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE);
+
+		qf = queryFilterProcessor.newQueryFilter("subClassAField=ne:Subclass A field", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(1).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE_2);
+
+		qf.deleteField("subClassAField");
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(4).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE, SUBCLASS_A_EXAMPLE_2,
+				SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2);
+
+		qf = queryFilterProcessor.newQueryFilter("sort=-subClassAField", QFParamType.RHS_COLON);
+
+		// On Hibernate 6, the sort will only do a Left Join on the subclassA table and all data from SubclassB will be returned
+		list = repository.findAll(qf);
+
+		// Nulls are returned first
+		assertThat(list).hasSize(4).containsExactly(SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2, SUBCLASS_A_EXAMPLE_2,
+				SUBCLASS_A_EXAMPLE);
+
+		qf = queryFilterProcessor.newQueryFilter("sort=-subClassAField&subClassAField=null:true",
+				QFParamType.RHS_COLON);
+
+		// Found also data from SubclassB
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactly(SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2);
+
+		qf = queryFilterProcessor.newQueryFilter("sort=-subClassAField&subClassAField=null:false",
+				QFParamType.RHS_COLON);
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactly(SUBCLASS_A_EXAMPLE_2, SUBCLASS_A_EXAMPLE);
+
+	}
+
+	@Test
+	@DisplayName("END. Test by clear BBDD")
+	@Order(Ordered.LOWEST_PRECEDENCE)
+	void clearBBDD() {
+		repository.deleteAll();
+		assertThat(repository.findAll()).isEmpty();
+	}
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/DiscriminatorRelatedJoinTest.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/DiscriminatorRelatedJoinTest.java
@@ -1,0 +1,231 @@
+package io.github.acoboh.query.filter.jpa.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import io.github.acoboh.query.filter.jpa.domain.FilterRelatedParentEntityDef;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity.TypeEnum;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.RelatedParent;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassAEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassBEntity;
+import io.github.acoboh.query.filter.jpa.repositories.ParentEntityRepository;
+import io.github.acoboh.query.filter.jpa.repositories.RelatedParentEntityRepository;
+import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
+
+/**
+ * Discriminator join tests
+ */
+@SpringJUnitWebConfig(SpringIntegrationTestBase.Config.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DiscriminatorRelatedJoinTest {
+
+	private static final SubclassAEntity SUBCLASS_A_EXAMPLE = new SubclassAEntity();
+	private static final SubclassAEntity SUBCLASS_A_EXAMPLE_2 = new SubclassAEntity();
+
+	private static final SubclassBEntity SUBCLASS_B_EXAMPLE = new SubclassBEntity();
+	private static final SubclassBEntity SUBCLASS_B_EXAMPLE_2 = new SubclassBEntity();
+
+	// Subclass A
+	private static final RelatedParent RELATED_PARENT = new RelatedParent();
+	private static final RelatedParent RELATED_PARENT_2 = new RelatedParent();
+
+	// Subclass B
+	private static final RelatedParent RELATED_PARENT_3 = new RelatedParent();
+	private static final RelatedParent RELATED_PARENT_4 = new RelatedParent();
+
+	// Repeated subclas 1 A and B
+	private static final RelatedParent RELATED_PARENT_5 = new RelatedParent();
+	private static final RelatedParent RELATED_PARENT_6 = new RelatedParent();
+
+	static {
+		SUBCLASS_A_EXAMPLE.setId("1");
+		SUBCLASS_A_EXAMPLE.setActive(true);
+		SUBCLASS_A_EXAMPLE.setType(TypeEnum.A);
+		SUBCLASS_A_EXAMPLE.setSubClassField("Subclass A field");
+		SUBCLASS_A_EXAMPLE.setFlag(true);
+
+		SUBCLASS_A_EXAMPLE_2.setId("2");
+		SUBCLASS_A_EXAMPLE_2.setActive(false);
+		SUBCLASS_A_EXAMPLE_2.setType(TypeEnum.A);
+		SUBCLASS_A_EXAMPLE_2.setSubClassField("Subclass A field 2");
+		SUBCLASS_A_EXAMPLE_2.setFlag(false);
+
+		SUBCLASS_B_EXAMPLE.setId("3");
+		SUBCLASS_B_EXAMPLE.setActive(true);
+		SUBCLASS_B_EXAMPLE.setType(TypeEnum.B);
+		SUBCLASS_B_EXAMPLE.setText("Subclass B text");
+
+		SUBCLASS_B_EXAMPLE_2.setId("4");
+		SUBCLASS_B_EXAMPLE_2.setActive(false);
+		SUBCLASS_B_EXAMPLE_2.setType(TypeEnum.B);
+		SUBCLASS_B_EXAMPLE_2.setText("Subclass B text 2");
+
+		// Parents A
+		RELATED_PARENT.setId("1");
+		RELATED_PARENT.setParent(SUBCLASS_A_EXAMPLE);
+
+		RELATED_PARENT_2.setId("2");
+		RELATED_PARENT_2.setParent(SUBCLASS_A_EXAMPLE_2);
+
+		// Parents B
+		RELATED_PARENT_3.setId("3");
+		RELATED_PARENT_3.setParent(SUBCLASS_B_EXAMPLE);
+
+		RELATED_PARENT_4.setId("4");
+		RELATED_PARENT_4.setParent(SUBCLASS_B_EXAMPLE_2);
+
+		// Parents A and B
+		RELATED_PARENT_5.setId("5");
+		RELATED_PARENT_5.setParent(SUBCLASS_A_EXAMPLE);
+
+		RELATED_PARENT_6.setId("6");
+		RELATED_PARENT_6.setParent(SUBCLASS_B_EXAMPLE);
+	}
+
+	@Autowired
+	private QFProcessor<FilterRelatedParentEntityDef, RelatedParent> queryFilterProcessor;
+
+	@Autowired
+	private ParentEntityRepository parentRepository;
+
+	@Autowired
+	private RelatedParentEntityRepository repository;
+
+	@Test
+	@DisplayName("0. Setup")
+	@Order(0)
+	void setup() {
+
+		assertThat(queryFilterProcessor).isNotNull();
+		assertThat(repository).isNotNull();
+
+		assertThat(repository.findAll()).isEmpty();
+
+		parentRepository.save(SUBCLASS_A_EXAMPLE);
+		parentRepository.save(SUBCLASS_A_EXAMPLE_2);
+		parentRepository.save(SUBCLASS_B_EXAMPLE);
+		parentRepository.save(SUBCLASS_B_EXAMPLE_2);
+		parentRepository.flush();
+
+		repository.save(RELATED_PARENT);
+		repository.save(RELATED_PARENT_2);
+		repository.save(RELATED_PARENT_3);
+		repository.save(RELATED_PARENT_4);
+		repository.save(RELATED_PARENT_5);
+		repository.save(RELATED_PARENT_6);
+		repository.flush();
+
+		assertThat(parentRepository.findAll()).hasSize(4).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE,
+				SUBCLASS_A_EXAMPLE_2, SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2);
+
+		assertThat(repository.findAll()).hasSize(6).containsExactlyInAnyOrder(RELATED_PARENT, RELATED_PARENT_2,
+				RELATED_PARENT_3, RELATED_PARENT_4, RELATED_PARENT_5, RELATED_PARENT_6);
+
+	}
+
+	@Test
+	@DisplayName("1. Filter by parent class")
+	@Order(1)
+	void filterByParentClass() {
+
+		QueryFilter<RelatedParent> qf = queryFilterProcessor.newQueryFilter("type=eq:A", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<RelatedParent> list = repository.findAll(qf);
+		assertThat(list).hasSize(3).containsExactlyInAnyOrder(RELATED_PARENT, RELATED_PARENT_2, RELATED_PARENT_5);
+
+		qf = queryFilterProcessor.newQueryFilter("type=eq:B", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(3).containsExactlyInAnyOrder(RELATED_PARENT_3, RELATED_PARENT_4, RELATED_PARENT_6);
+
+	}
+
+	@Test
+	@DisplayName("2. Filter by discriminator class")
+	@Order(2)
+	void filterByDiscriminatorClass() {
+
+		QueryFilter<RelatedParent> qf = queryFilterProcessor.newQueryFilter("discriminatorType=eq:subclassA",
+				QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<RelatedParent> list = repository.findAll(qf);
+		assertThat(list).hasSize(3).containsExactlyInAnyOrder(RELATED_PARENT, RELATED_PARENT_2, RELATED_PARENT_5);
+
+		qf = queryFilterProcessor.newQueryFilter("discriminatorType=eq:subclassB", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(3).containsExactlyInAnyOrder(RELATED_PARENT_3, RELATED_PARENT_4, RELATED_PARENT_6);
+
+	}
+
+	@Test
+	@DisplayName("3. Filter by subclass a field")
+	@Order(3)
+	void filterBySubclassAField() {
+
+		QueryFilter<RelatedParent> qf = queryFilterProcessor.newQueryFilter("subClassAField=eq:Subclass A field",
+				QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<RelatedParent> list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactlyInAnyOrder(RELATED_PARENT, RELATED_PARENT_5);
+
+		qf = queryFilterProcessor.newQueryFilter("subClassAField=ne:Subclass A field", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(1).containsExactlyInAnyOrder(RELATED_PARENT_2);
+
+		qf.deleteField("subClassAField");
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(6).containsExactlyInAnyOrder(RELATED_PARENT, RELATED_PARENT_2, RELATED_PARENT_3,
+				RELATED_PARENT_4, RELATED_PARENT_5, RELATED_PARENT_6);
+
+		qf = queryFilterProcessor.newQueryFilter("sort=+subClassAField", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		// If the field is from nested entity, it will apply a inner join
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(3).containsExactly(RELATED_PARENT, RELATED_PARENT_5, RELATED_PARENT_2);
+
+	}
+
+	@Test
+	@DisplayName("END. Test by clear BBDD")
+	@Order(Ordered.LOWEST_PRECEDENCE)
+	void clearBBDD() {
+		repository.deleteAll();
+		assertThat(repository.findAll()).isEmpty();
+
+		parentRepository.deleteAll();
+		assertThat(parentRepository.findAll()).isEmpty();
+	}
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/errors/TestQFProcessorErrors.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/errors/TestQFProcessorErrors.java
@@ -1,0 +1,43 @@
+package io.github.acoboh.query.filter.jpa.processor.errors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import io.github.acoboh.query.filter.jpa.exceptions.definition.QFDiscriminatorException;
+import io.github.acoboh.query.filter.jpa.filtererrors.discriminator.DiscriminatorFilterErrorDef;
+import io.github.acoboh.query.filter.jpa.model.discriminators.Topic;
+import io.github.acoboh.query.filter.jpa.processor.QFProcessor;
+import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
+
+@SpringJUnitWebConfig(SpringIntegrationTestBase.Config.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class TestQFProcessorErrors {
+
+	@Autowired
+	private ApplicationContext appContext;
+
+	@Test
+	@DisplayName("1. Test QFProcessor Discriminator with not inherited class")
+	void testDiscriminatorNotInherited() {
+
+		QFDiscriminatorException ex = assertThrows(QFDiscriminatorException.class, () -> {
+			new QFProcessor<>(DiscriminatorFilterErrorDef.class, Topic.class, appContext);
+		});
+
+		assertThat(ex.getMessage()).isEqualTo(
+				"Entity class 'class io.github.acoboh.query.filter.jpa.model.discriminators.Topic' is not assignable from value class 'class io.github.acoboh.query.filter.jpa.model.PostBlog'");
+	}
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/repositories/ParentEntityRepository.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/repositories/ParentEntityRepository.java
@@ -1,0 +1,14 @@
+package io.github.acoboh.query.filter.jpa.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity;
+
+/**
+ * Parent entity repository
+ */
+public interface ParentEntityRepository
+		extends JpaSpecificationExecutor<ParentEntity>, JpaRepository<ParentEntity, String> {
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/repositories/RelatedParentEntityRepository.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/repositories/RelatedParentEntityRepository.java
@@ -1,0 +1,14 @@
+package io.github.acoboh.query.filter.jpa.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.RelatedParent;
+
+/**
+ * Related parent entity repository
+ */
+public interface RelatedParentEntityRepository
+		extends JpaSpecificationExecutor<RelatedParent>, JpaRepository<RelatedParent, String> {
+
+}

--- a/query-filter-jpa-3/src/test/resources/logback-test.xml
+++ b/query-filter-jpa-3/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
 	</appender>
 
 	<logger name="io.github.acoboh" level="DEBUG"/>
-	<logger name="org.hibernate.SQL" level="DEBUG"/>
+	<logger name="net.ttddyy" level="DEBUG"/>
 	
 	<root level="INFO">
 		<appender-ref ref="STDOUT" />

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFCollectionElement.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFCollectionElement.java
@@ -32,4 +32,46 @@ public @interface QFCollectionElement {
 	 * @return name
 	 */
 	String name() default "";
+
+	/**
+	 * Select the class of the element if it is only available on a nested Discriminator class.
+	 * <p>
+	 * Example: <blockquote>
+	 * 
+	 * <pre>
+	 * &#64;Entity
+	 * &#64;Inheritance(strategy = InheritanceType.JOINED)
+	 * public class ParentEntity {
+	 *     // Base data
+	 * }
+	 * 
+	 * &#64;Entity
+	 * public class SubclassAEntity extends ParentEntity {
+	 *     // Subclass A data
+	 *     &#64;OneToMany
+	 *     private List links;
+	 * }
+	 * 
+	 * &#64;QFDefinitionClass(ParentEntity.class)
+	 * public class FilterParentEntityDef {
+	 *    &#64;QFCollectionElement(value = "links", subClassMapping = SubclassAEntity.class)
+	 *    private int links;
+	 * }
+	 * }
+	 * </pre>
+	 * 
+	 * </blockquote>
+	 * 
+	 * @return subClassMapping
+	 */
+	Class<?> subClassMapping() default Void.class;
+
+	/**
+	 * Select the path of the subclass level if it is only available on a nested Discriminator class.
+	 * <p>
+	 * Need to be used with {@linkplain #subClassMapping()}
+	 * 
+	 * @return path to apply subclass scanning
+	 */
+	String subClassMappingPath() default "";
 }

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFElement.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFElement.java
@@ -146,4 +146,43 @@ public @interface QFElement {
 	 */
 	boolean autoFetch() default true;
 
+	/**
+	 * Select the class of the element if it is only available on a nested Discriminator class.
+	 * <p>
+	 * Example: <blockquote>
+	 * 
+	 * <pre>
+	 * {@code @Entity }
+	 * {@code @Inheritance(strategy = InheritanceType.JOINED)}
+	 * public class ParentEntity {
+	 *     // Base data
+	 * }
+	 * 
+	 * {@code @Entity }
+	 * public class SubclassAEntity extends ParentEntity {
+	 *     // Subclass A data
+	 *     private String subClassField;
+	 * }
+	 * 
+	 * {@code @QFDefinitionClass(ParentEntity.class)}
+	 * public class FilterParentEntityDef {
+	 *    {@code @QFElement(value = "subClassField", subClassMapping = SubclassAEntity.class)}
+	 *    private String subClassField;
+	 * {@code}}
+	 * </pre>
+	 * 
+	 * </blockquote>
+	 * 
+	 * @return subClassMapping
+	 */
+	Class<?> subClassMapping() default Void.class;
+
+	/**
+	 * Select the path of the subclass level if it is only available on a nested Discriminator class.
+	 * <p>
+	 * Need to be used with {@linkplain #subClassMapping()}
+	 * 
+	 * @return path to apply subclass scanning
+	 */
+	String subClassMappingPath() default "";
 }

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/config/QFBeanFactoryPostProcessor.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/config/QFBeanFactoryPostProcessor.java
@@ -34,7 +34,6 @@ import org.springframework.util.Assert;
 
 import io.github.acoboh.query.filter.jpa.annotations.EnableQueryFilter;
 import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
-import io.github.acoboh.query.filter.jpa.exceptions.QueryFilterException;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
 import io.github.acoboh.query.filter.jpa.processor.QFProcessor;
 
@@ -172,7 +171,7 @@ public class QFBeanFactoryPostProcessor implements ApplicationContextAware, Bean
 				QFProcessor<?, ?> qfp = registerQueryFilterClass(cl, beanFactory);
 				mapProcessors.put(cl, qfp);
 			} catch (QueryFilterDefinitionException e) {
-				throw new BeanCreationException("Error creating bean query filter", e);
+				throw new BeanCreationException("Error creating bean query filter for class " + cl.getName(), e);
 			}
 		}
 
@@ -203,8 +202,9 @@ public class QFBeanFactoryPostProcessor implements ApplicationContextAware, Bean
 			QFProcessor<?, ?> ret = new QFProcessor<>(cl, annotationClass.value(), applicationContext);
 			bf.registerSingleton(beanName, ret);
 			return ret;
-		} catch (QueryFilterException e) {
-			LOGGER.error("Error registering bean query filter of class {}", cl);
+		} catch (QueryFilterDefinitionException e) {
+			LOGGER.error("Error registering bean query filter of class {} for entity class {}", cl,
+					annotationClass.value());
 			throw e;
 		}
 

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/QFPath.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/QFPath.java
@@ -50,6 +50,8 @@ public class QFPath {
 
 	private boolean isFinal;
 
+	private final Class<?> treatClass;
+
 	/**
 	 * Default constructor
 	 *
@@ -58,13 +60,16 @@ public class QFPath {
 	 * @param path       path
 	 * @param fieldClass field class
 	 * @param isFinal    if the field is final
+	 * @param treatClass treat class
 	 */
-	public QFPath(Field field, String path, QFElementDefType type, Class<?> fieldClass, boolean isFinal) {
+	public QFPath(Field field, String path, QFElementDefType type, Class<?> fieldClass, boolean isFinal,
+			Class<?> treatClass) {
 		this.type = type;
 		this.field = field;
 		this.path = path;
 		this.fieldClass = fieldClass;
 		this.isFinal = isFinal;
+		this.treatClass = treatClass;
 	}
 
 	/**
@@ -137,6 +142,28 @@ public class QFPath {
 	 */
 	public String getPath() {
 		return path;
+	}
+
+	/**
+	 * Get path name for map with treat class
+	 * 
+	 * @return path name
+	 */
+	public String getPathName() {
+		if (treatClass != null && !Void.class.equals(treatClass)) {
+			return path + "-asTreat-" + treatClass.getSimpleName();
+		}
+
+		return path;
+	}
+
+	/**
+	 * Get treat class
+	 * 
+	 * @return null if not set
+	 */
+	public Class<?> getTreatClass() {
+		return treatClass;
 	}
 
 }

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/QueryFilter.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/QueryFilter.java
@@ -211,7 +211,10 @@ public class QueryFilter<E> implements Specification<E> {
 
 		Matcher matcher = REGEX_PATTERN.matcher(values);
 
+		boolean match = false;
 		while (matcher.find()) {
+			match = true;
+
 			String order = matcher.group(1);
 			String fieldName = matcher.group(2);
 
@@ -220,7 +223,7 @@ public class QueryFilter<E> implements Specification<E> {
 				throw new QFFieldNotFoundException(fieldName);
 			}
 
-			if (!(def instanceof IDefinitionSortable)) {
+			if (!(def instanceof IDefinitionSortable) || !((IDefinitionSortable) def).isSortable()) {
 				throw new QFNotSortableException(fieldName);
 			}
 
@@ -238,6 +241,10 @@ public class QueryFilter<E> implements Specification<E> {
 			Pair<IDefinitionSortable, Direction> pair = Pair.of((IDefinitionSortable) def, dir);
 			this.sortDefinitionList.add(pair);
 			this.defaultSortEnabled = false;
+		}
+
+		if (!match) {
+			throw new QFParseException(values, initialInput);
 		}
 
 	}
@@ -399,7 +406,7 @@ public class QueryFilter<E> implements Specification<E> {
 			throw new QFFieldNotFoundException(field);
 		}
 
-		if (!(def instanceof IDefinitionSortable)) {
+		if (!(def instanceof IDefinitionSortable) || !((IDefinitionSortable) def).isSortable()) {
 			throw new QFNotSortableException(field);
 		}
 

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/FieldClassProcessor.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/FieldClassProcessor.java
@@ -26,11 +26,17 @@ class FieldClassProcessor {
 	private List<QFPath> paths;
 	private Class<?> finalClass;
 
-	FieldClassProcessor(Class<?> rootClass, String pathField, boolean checkFinal) {
+	private final Class<?> subclassMapping;
+	private final String subClassMappingPath;
+
+	FieldClassProcessor(Class<?> rootClass, String pathField, boolean checkFinal, Class<?> subclassMapping,
+			String subClassMappingPath) {
 		Assert.notNull(pathField, "Path field cannot be null");
 		this.rootClass = rootClass;
 		this.pathField = pathField;
 		this.checkFinal = checkFinal;
+		this.subclassMapping = subclassMapping;
+		this.subClassMappingPath = subClassMappingPath;
 	}
 
 	public List<QFPath> getPaths() throws QueryFilterDefinitionException {
@@ -45,17 +51,48 @@ class FieldClassProcessor {
 			throw new QFElementException(pathField, rootClass);
 		}
 
+		String[] levelsSubClass = null;
+
+		if (subclassMapping != null && !Void.class.equals(subclassMapping)) {
+			LOGGER.trace("Processing subclass mapping {}", subclassMapping);
+			if (subClassMappingPath != null && !subClassMappingPath.isEmpty()
+					&& !pathField.startsWith(subClassMappingPath)) {
+				LOGGER.trace("Subclass mapping path '{}' not present in path field '{}'", subClassMappingPath,
+						pathField);
+				throw new QFElementException(pathField, subclassMapping);
+			}
+			if (subClassMappingPath.isEmpty()) {
+				levelsSubClass = new String[0];
+			} else {
+				levelsSubClass = subClassMappingPath.split("\\.");
+			}
+			
+		}
+
 		Class<?> levelClass = rootClass;
 
+		int actualLevel = -1;
 		for (String level : splitLevel) {
+			Class<?> treatClass = null;
+			actualLevel++;
+
 			LOGGER.trace("Processing level {}", level);
+
+			if (levelsSubClass != null && levelsSubClass.length == actualLevel) {
+				// Check levelClass is parent of subclassMapping
+				if (!levelClass.isAssignableFrom(subclassMapping)) {
+					throw new QFElementException(pathField, subclassMapping);
+				}
+				treatClass = subclassMapping;
+				levelClass = subclassMapping;
+			}
 
 			Field fieldObject = ClassUtils.getDeclaredFieldSuperclass(levelClass, level);
 			if (fieldObject == null) {
 				throw new QFElementException(pathField, levelClass);
 			}
 
-			QFPath path = createQPathOfField(fieldObject, level);
+			QFPath path = createQPathOfField(fieldObject, level, treatClass);
 			paths.add(path);
 
 			// Check path is final and nested levels are present
@@ -92,7 +129,8 @@ class FieldClassProcessor {
 		return finalClass;
 	}
 
-	private static QFPath createQPathOfField(Field field, String path) throws QueryFilterDefinitionException {
+	private static QFPath createQPathOfField(Field field, String path, Class<?> treatClass)
+			throws QueryFilterDefinitionException {
 
 		LOGGER.trace("Processing field {}", field);
 
@@ -118,7 +156,7 @@ class FieldClassProcessor {
 			type = QFElementDefType.PROPERTY;
 		}
 
-		return new QFPath(field, path, type, finalClass, isFinal);
+		return new QFPath(field, path, type, finalClass, isFinal, treatClass);
 	}
 
 	private static boolean couldBeFinal(Class<?> clazz) {

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
@@ -25,9 +25,8 @@ public class QFDefinitionCollection extends QFAbstractDefinition {
 			QFCollectionElement collectionElement) throws QueryFilterDefinitionException {
 		super(filterField, filterClass, entityClass, blockParsing);
 
-		// TODO Fix
 		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, collectionElement.value(), false,
-				null, null);
+				collectionElement.subClassMapping(), collectionElement.subClassMappingPath());
 
 		this.paths = fieldClassProcessor.getPaths();
 

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
@@ -25,7 +25,9 @@ public class QFDefinitionCollection extends QFAbstractDefinition {
 			QFCollectionElement collectionElement) throws QueryFilterDefinitionException {
 		super(filterField, filterClass, entityClass, blockParsing);
 
-		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, collectionElement.value(), false);
+		// TODO Fix
+		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, collectionElement.value(), false,
+				null, null);
 
 		this.paths = fieldClassProcessor.getPaths();
 

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
@@ -33,7 +33,7 @@ public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 		if (!discriminatorAnnotation.path().isEmpty()) {
 			// Process path
 			FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass,
-					discriminatorAnnotation.path(), false, null, null); // TODO Fix
+					discriminatorAnnotation.path(), false, null, null);
 			this.paths = fieldClassProcessor.getPaths();
 			this.finalClass = fieldClassProcessor.getFinalClass();
 

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
@@ -29,7 +29,6 @@ public class QFDefinitionJson extends QFAbstractDefinition {
 			super.filterName = jsonAnnotation.name();
 		}
 
-		// TODO Fix
 		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, jsonAnnotation.value(), false,
 				null, null);
 

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
@@ -29,7 +29,9 @@ public class QFDefinitionJson extends QFAbstractDefinition {
 			super.filterName = jsonAnnotation.name();
 		}
 
-		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, jsonAnnotation.value(), false);
+		// TODO Fix
+		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, jsonAnnotation.value(), false,
+				null, null);
 
 		this.paths = fieldClassProcessor.getPaths();
 

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
@@ -28,8 +28,9 @@ public class QFDefinitionSortable extends QFAbstractDefinition implements IDefin
 
 		paths = new ArrayList<>(1); // Only one path
 
-		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, sortableAnnotation.value(),
-				true);
+		// TODO Fix
+		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, sortableAnnotation.value(), true,
+				null, null);
 		paths.add(fieldClassProcessor.getPaths());
 
 		autoFetch = sortableAnnotation.autoFetch();

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
@@ -28,7 +28,6 @@ public class QFDefinitionSortable extends QFAbstractDefinition implements IDefin
 
 		paths = new ArrayList<>(1); // Only one path
 
-		// TODO Fix
 		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, sortableAnnotation.value(), true,
 				null, null);
 		paths.add(fieldClassProcessor.getPaths());

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFCollectionMatch.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFCollectionMatch.java
@@ -81,7 +81,7 @@ public class QFCollectionMatch implements QFSpecificationPart {
 			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
 			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass) {
 
-		Path<?> expressionPath = QueryUtils.getObject(root, definition.getPaths(), pathsMap, true, false);
+		Path<?> expressionPath = QueryUtils.getObject(root, definition.getPaths(), pathsMap, true, false, criteriaBuilder);
 
 		Expression<? extends java.util.Collection<?>> expression;
 

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFElementMatch.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFElementMatch.java
@@ -465,7 +465,7 @@ public class QFElementMatch implements QFSpecificationPart {
 		List<Expression<Boolean>> expressions = surrondingPredicate.getExpressions();
 
 		for (List<QFPath> path : paths) {
-			expressions.add(operation.generatePredicate(QueryUtils.getObject(root, path, pathsMap, false, false),
+			expressions.add(operation.generatePredicate(QueryUtils.getObject(root, path, pathsMap, false, false, criteriaBuilder),
 					criteriaBuilder, this, index, mlmap));
 			index++;
 		}
@@ -493,7 +493,7 @@ public class QFElementMatch implements QFSpecificationPart {
 
 			subquery.select(newRoot.as(entityClass));
 
-			Path<?> pathFinal = QueryUtils.getObject(newRoot, path, subSelecthMap, false, false);
+			Path<?> pathFinal = QueryUtils.getObject(newRoot, path, subSelecthMap, false, false, criteriaBuilder);
 
 			QFOperationEnum op = operation;
 			if (op == QFOperationEnum.NOT_EQUAL) {

--- a/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFJsonElementMatch.java
+++ b/query-filter-jpa/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFJsonElementMatch.java
@@ -166,8 +166,8 @@ public class QFJsonElementMatch implements QFSpecificationPart {
 
 		predicatesMap.computeIfAbsent(definition.getFilterName(), t -> new ArrayList<>())
 				.add(operation.generateJsonPredicate(
-						QueryUtils.getObject(root, definition.getPaths(), pathsMap, true, false), criteriaBuilder,
-						this));
+						QueryUtils.getObject(root, definition.getPaths(), pathsMap, true, false, criteriaBuilder),
+						criteriaBuilder, this));
 
 	}
 

--- a/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterParentEntityDef.java
+++ b/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterParentEntityDef.java
@@ -1,0 +1,27 @@
+package io.github.acoboh.query.filter.jpa.domain;
+
+import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
+import io.github.acoboh.query.filter.jpa.annotations.QFDiscriminator;
+import io.github.acoboh.query.filter.jpa.annotations.QFElement;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity.TypeEnum;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassAEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassBEntity;
+
+/**
+ * Parent entity discriminators filter class
+ */
+@QFDefinitionClass(ParentEntity.class)
+public class FilterParentEntityDef {
+
+	@QFElement("type")
+	private TypeEnum type;
+
+	@QFDiscriminator({ @QFDiscriminator.Value(name = "subclassA", type = SubclassAEntity.class),
+			@QFDiscriminator.Value(name = "subclassB", type = SubclassBEntity.class) })
+	private String discriminatorType;
+
+	@QFElement(value = "subClassField", subClassMapping = SubclassAEntity.class)
+	private String subClassAField;
+
+}

--- a/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterRelatedParentEntityDef.java
+++ b/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterRelatedParentEntityDef.java
@@ -1,0 +1,28 @@
+package io.github.acoboh.query.filter.jpa.domain;
+
+import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
+import io.github.acoboh.query.filter.jpa.annotations.QFDiscriminator;
+import io.github.acoboh.query.filter.jpa.annotations.QFElement;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity.TypeEnum;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.RelatedParent;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassAEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassBEntity;
+
+/**
+ * Parent entity discriminators filter class
+ */
+@QFDefinitionClass(RelatedParent.class)
+public class FilterRelatedParentEntityDef {
+
+	@QFElement("parent.type")
+	private TypeEnum type;
+
+	@QFDiscriminator(path = "parent", value = {
+			@QFDiscriminator.Value(name = "subclassA", type = SubclassAEntity.class),
+			@QFDiscriminator.Value(name = "subclassB", type = SubclassBEntity.class) })
+	private String discriminatorType;
+
+	@QFElement(value = "parent.subClassField", subClassMapping = SubclassAEntity.class, subClassMappingPath = "parent")
+	private String subClassAField;
+
+}

--- a/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/ParentEntity.java
+++ b/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/ParentEntity.java
@@ -1,0 +1,109 @@
+package io.github.acoboh.query.filter.jpa.model.discriminators.joined;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+/**
+ * Parent entity
+ */
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+public abstract class ParentEntity {
+
+	/**
+	 * Type enum
+	 */
+	public enum TypeEnum {
+		/**
+		 * A type
+		 */
+		A,
+		/**
+		 * B type
+		 */
+		B
+	}
+
+	@Id
+	private String id;
+
+	private TypeEnum type;
+
+	private boolean active = false;
+
+	/**
+	 * Get the id
+	 * 
+	 * @return the id
+	 */
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * Set the id
+	 * 
+	 * @param id
+	 */
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	/**
+	 * Get the type
+	 * 
+	 * @return the type
+	 */
+	public TypeEnum getType() {
+		return type;
+	}
+
+	/**
+	 * Set the type
+	 * 
+	 * @param type
+	 */
+	public void setType(TypeEnum type) {
+		this.type = type;
+	}
+
+	/**
+	 * Get the active
+	 * 
+	 * @return the active
+	 */
+	public boolean isActive() {
+		return active;
+	}
+
+	/**
+	 * Set the active
+	 * 
+	 * @param active
+	 */
+	public void setActive(boolean active) {
+		this.active = active;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(active, id, type);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ParentEntity other = (ParentEntity) obj;
+		return active == other.active && Objects.equals(id, other.id) && type == other.type;
+	}
+
+}

--- a/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/RelatedParent.java
+++ b/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/RelatedParent.java
@@ -1,0 +1,76 @@
+package io.github.acoboh.query.filter.jpa.model.discriminators.joined;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+/**
+ * Related parent entity
+ */
+@Entity
+public class RelatedParent {
+
+	@Id
+	private String id;
+
+	@ManyToOne
+	@JoinColumn(name = "parent_id")
+	private ParentEntity parent;
+
+	/**
+	 * Get the id
+	 * 
+	 * @return the id
+	 */
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * Set the id
+	 * 
+	 * @param id
+	 */
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	/**
+	 * Get the parent
+	 * 
+	 * @return the parent
+	 */
+	public ParentEntity getParent() {
+		return parent;
+	}
+
+	/**
+	 * Set the parent
+	 * 
+	 * @param parent
+	 */
+	public void setParent(ParentEntity parent) {
+		this.parent = parent;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, parent);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		RelatedParent other = (RelatedParent) obj;
+		return Objects.equals(id, other.id) && Objects.equals(parent, other.parent);
+	}
+
+}

--- a/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/SubclassAEntity.java
+++ b/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/SubclassAEntity.java
@@ -1,0 +1,73 @@
+package io.github.acoboh.query.filter.jpa.model.discriminators.joined;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+
+/**
+ * Subclass A entity
+ */
+@Entity
+public class SubclassAEntity extends ParentEntity {
+
+	private String subClassField;
+
+	private boolean flag;
+
+	/**
+	 * Get the sub class field
+	 * 
+	 * @return the sub class field
+	 */
+	public String getSubClassField() {
+		return subClassField;
+	}
+
+	/**
+	 * Set the subclass field
+	 * 
+	 * @param subClassField
+	 */
+	public void setSubClassField(String subClassField) {
+		this.subClassField = subClassField;
+	}
+
+	/**
+	 * Get the flag
+	 * 
+	 * @return the flag
+	 */
+	public boolean isFlag() {
+		return flag;
+	}
+
+	/**
+	 * Set the flag
+	 * 
+	 * @param flag
+	 */
+	public void setFlag(boolean flag) {
+		this.flag = flag;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + Objects.hash(flag, subClassField);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SubclassAEntity other = (SubclassAEntity) obj;
+		return flag == other.flag && Objects.equals(subClassField, other.subClassField);
+	}
+
+}

--- a/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/SubclassBEntity.java
+++ b/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/model/discriminators/joined/SubclassBEntity.java
@@ -1,0 +1,53 @@
+package io.github.acoboh.query.filter.jpa.model.discriminators.joined;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+
+/**
+ * Subclass B entity
+ */
+@Entity
+public class SubclassBEntity extends ParentEntity {
+
+	private String text;
+
+	/**
+	 * Get the text
+	 * 
+	 * @return the text
+	 */
+	public String getText() {
+		return text;
+	}
+
+	/**
+	 * Set the text
+	 * 
+	 * @param text
+	 */
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + Objects.hash(text);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SubclassBEntity other = (SubclassBEntity) obj;
+		return Objects.equals(text, other.text);
+	}
+
+}

--- a/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/processor/DiscriminatorJoinTest.java
+++ b/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/processor/DiscriminatorJoinTest.java
@@ -1,0 +1,192 @@
+package io.github.acoboh.query.filter.jpa.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import io.github.acoboh.query.filter.jpa.domain.FilterParentEntityDef;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity.TypeEnum;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassAEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassBEntity;
+import io.github.acoboh.query.filter.jpa.repositories.ParentEntityRepository;
+import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
+
+/**
+ * Discriminator join tests
+ */
+@SpringJUnitWebConfig(SpringIntegrationTestBase.Config.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DiscriminatorJoinTest {
+
+	private static final SubclassAEntity SUBCLASS_A_EXAMPLE = new SubclassAEntity();
+	private static final SubclassAEntity SUBCLASS_A_EXAMPLE_2 = new SubclassAEntity();
+
+	private static final SubclassBEntity SUBCLASS_B_EXAMPLE = new SubclassBEntity();
+	private static final SubclassBEntity SUBCLASS_B_EXAMPLE_2 = new SubclassBEntity();
+
+	static {
+		SUBCLASS_A_EXAMPLE.setId("1");
+		SUBCLASS_A_EXAMPLE.setActive(true);
+		SUBCLASS_A_EXAMPLE.setType(TypeEnum.A);
+		SUBCLASS_A_EXAMPLE.setSubClassField("Subclass A field");
+		SUBCLASS_A_EXAMPLE.setFlag(true);
+
+		SUBCLASS_A_EXAMPLE_2.setId("2");
+		SUBCLASS_A_EXAMPLE_2.setActive(false);
+		SUBCLASS_A_EXAMPLE_2.setType(TypeEnum.A);
+		SUBCLASS_A_EXAMPLE_2.setSubClassField("Subclass A field 2");
+		SUBCLASS_A_EXAMPLE_2.setFlag(false);
+
+		SUBCLASS_B_EXAMPLE.setId("3");
+		SUBCLASS_B_EXAMPLE.setActive(true);
+		SUBCLASS_B_EXAMPLE.setType(TypeEnum.B);
+		SUBCLASS_B_EXAMPLE.setText("Subclass B text");
+
+		SUBCLASS_B_EXAMPLE_2.setId("4");
+		SUBCLASS_B_EXAMPLE_2.setActive(false);
+		SUBCLASS_B_EXAMPLE_2.setType(TypeEnum.B);
+		SUBCLASS_B_EXAMPLE_2.setText("Subclass B text 2");
+
+	}
+
+	@Autowired
+	private QFProcessor<FilterParentEntityDef, ParentEntity> queryFilterProcessor;
+
+	@Autowired
+	private ParentEntityRepository repository;
+
+	@Test
+	@DisplayName("0. Setup")
+	@Order(0)
+	void setup() {
+
+		assertThat(queryFilterProcessor).isNotNull();
+		assertThat(repository).isNotNull();
+
+		assertThat(repository.findAll()).isEmpty();
+
+		repository.save(SUBCLASS_A_EXAMPLE);
+		repository.save(SUBCLASS_A_EXAMPLE_2);
+		repository.save(SUBCLASS_B_EXAMPLE);
+		repository.save(SUBCLASS_B_EXAMPLE_2);
+		repository.flush();
+
+		assertThat(repository.findAll()).hasSize(4).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE, SUBCLASS_A_EXAMPLE_2,
+				SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2);
+
+	}
+
+	@Test
+	@DisplayName("1. Filter by parent class")
+	@Order(1)
+	void filterByParentClass() {
+
+		QueryFilter<ParentEntity> qf = queryFilterProcessor.newQueryFilter("type=eq:A", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<ParentEntity> list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE, SUBCLASS_A_EXAMPLE_2);
+
+		qf = queryFilterProcessor.newQueryFilter("type=eq:B", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactlyInAnyOrder(SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2);
+
+	}
+
+	@Test
+	@DisplayName("2. Filter by discriminator class")
+	@Order(2)
+	void filterByDiscriminatorClass() {
+
+		QueryFilter<ParentEntity> qf = queryFilterProcessor.newQueryFilter("discriminatorType=eq:subclassA",
+				QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<ParentEntity> list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE, SUBCLASS_A_EXAMPLE_2);
+
+		qf = queryFilterProcessor.newQueryFilter("discriminatorType=eq:subclassB", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactlyInAnyOrder(SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2);
+
+	}
+
+	@Test
+	@DisplayName("3. Filter by subclass a field")
+	@Order(3)
+	void filterBySubclassAField() {
+
+		// On Hibernate 6, the filter will apply a Inner Join on the subclassAEntity table and only data from SubclassA will be returned
+		// matching the filter
+
+		QueryFilter<ParentEntity> qf = queryFilterProcessor.newQueryFilter("subClassAField=eq:Subclass A field",
+				QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<ParentEntity> list = repository.findAll(qf);
+		assertThat(list).hasSize(1).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE);
+
+		qf = queryFilterProcessor.newQueryFilter("subClassAField=ne:Subclass A field", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(1).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE_2);
+
+		qf.deleteField("subClassAField");
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(4).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE, SUBCLASS_A_EXAMPLE_2,
+				SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2);
+
+		qf = queryFilterProcessor.newQueryFilter("sort=-subClassAField", QFParamType.RHS_COLON);
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactly(SUBCLASS_A_EXAMPLE_2, SUBCLASS_A_EXAMPLE);
+
+		qf = queryFilterProcessor.newQueryFilter("sort=-subClassAField&subClassAField=null:true", QFParamType.RHS_COLON);
+
+		list = repository.findAll(qf);
+		assertThat(list).isEmpty();
+
+		qf = queryFilterProcessor.newQueryFilter("sort=-subClassAField&subClassAField=null:false",
+				QFParamType.RHS_COLON);
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactly(SUBCLASS_A_EXAMPLE_2, SUBCLASS_A_EXAMPLE);
+
+	}
+
+	@Test
+	@DisplayName("END. Test by clear BBDD")
+	@Order(Ordered.LOWEST_PRECEDENCE)
+	void clearBBDD() {
+		repository.deleteAll();
+		assertThat(repository.findAll()).isEmpty();
+	}
+
+}

--- a/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/processor/DiscriminatorRelatedJoinTest.java
+++ b/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/processor/DiscriminatorRelatedJoinTest.java
@@ -1,0 +1,223 @@
+package io.github.acoboh.query.filter.jpa.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import io.github.acoboh.query.filter.jpa.domain.FilterRelatedParentEntityDef;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity.TypeEnum;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.RelatedParent;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassAEntity;
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.SubclassBEntity;
+import io.github.acoboh.query.filter.jpa.repositories.ParentEntityRepository;
+import io.github.acoboh.query.filter.jpa.repositories.RelatedParentEntityRepository;
+import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
+
+/**
+ * Discriminator join tests
+ */
+@SpringJUnitWebConfig(SpringIntegrationTestBase.Config.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DiscriminatorRelatedJoinTest {
+
+	private static final SubclassAEntity SUBCLASS_A_EXAMPLE = new SubclassAEntity();
+	private static final SubclassAEntity SUBCLASS_A_EXAMPLE_2 = new SubclassAEntity();
+
+	private static final SubclassBEntity SUBCLASS_B_EXAMPLE = new SubclassBEntity();
+	private static final SubclassBEntity SUBCLASS_B_EXAMPLE_2 = new SubclassBEntity();
+
+	// Subclass A
+	private static final RelatedParent RELATED_PARENT = new RelatedParent();
+	private static final RelatedParent RELATED_PARENT_2 = new RelatedParent();
+
+	// Subclass B
+	private static final RelatedParent RELATED_PARENT_3 = new RelatedParent();
+	private static final RelatedParent RELATED_PARENT_4 = new RelatedParent();
+
+	// Repeated subclas 1 A and B
+	private static final RelatedParent RELATED_PARENT_5 = new RelatedParent();
+	private static final RelatedParent RELATED_PARENT_6 = new RelatedParent();
+
+	static {
+		SUBCLASS_A_EXAMPLE.setId("1");
+		SUBCLASS_A_EXAMPLE.setActive(true);
+		SUBCLASS_A_EXAMPLE.setType(TypeEnum.A);
+		SUBCLASS_A_EXAMPLE.setSubClassField("Subclass A field");
+		SUBCLASS_A_EXAMPLE.setFlag(true);
+
+		SUBCLASS_A_EXAMPLE_2.setId("2");
+		SUBCLASS_A_EXAMPLE_2.setActive(false);
+		SUBCLASS_A_EXAMPLE_2.setType(TypeEnum.A);
+		SUBCLASS_A_EXAMPLE_2.setSubClassField("Subclass A field 2");
+		SUBCLASS_A_EXAMPLE_2.setFlag(false);
+
+		SUBCLASS_B_EXAMPLE.setId("3");
+		SUBCLASS_B_EXAMPLE.setActive(true);
+		SUBCLASS_B_EXAMPLE.setType(TypeEnum.B);
+		SUBCLASS_B_EXAMPLE.setText("Subclass B text");
+
+		SUBCLASS_B_EXAMPLE_2.setId("4");
+		SUBCLASS_B_EXAMPLE_2.setActive(false);
+		SUBCLASS_B_EXAMPLE_2.setType(TypeEnum.B);
+		SUBCLASS_B_EXAMPLE_2.setText("Subclass B text 2");
+
+		// Parents A
+		RELATED_PARENT.setId("1");
+		RELATED_PARENT.setParent(SUBCLASS_A_EXAMPLE);
+
+		RELATED_PARENT_2.setId("2");
+		RELATED_PARENT_2.setParent(SUBCLASS_A_EXAMPLE_2);
+
+		// Parents B
+		RELATED_PARENT_3.setId("3");
+		RELATED_PARENT_3.setParent(SUBCLASS_B_EXAMPLE);
+
+		RELATED_PARENT_4.setId("4");
+		RELATED_PARENT_4.setParent(SUBCLASS_B_EXAMPLE_2);
+
+		// Parents A and B
+		RELATED_PARENT_5.setId("5");
+		RELATED_PARENT_5.setParent(SUBCLASS_A_EXAMPLE);
+
+		RELATED_PARENT_6.setId("6");
+		RELATED_PARENT_6.setParent(SUBCLASS_B_EXAMPLE);
+	}
+
+	@Autowired
+	private QFProcessor<FilterRelatedParentEntityDef, RelatedParent> queryFilterProcessor;
+
+	@Autowired
+	private ParentEntityRepository parentRepository;
+
+	@Autowired
+	private RelatedParentEntityRepository repository;
+
+	@Test
+	@DisplayName("0. Setup")
+	@Order(0)
+	void setup() {
+
+		assertThat(queryFilterProcessor).isNotNull();
+		assertThat(repository).isNotNull();
+
+		assertThat(repository.findAll()).isEmpty();
+
+		parentRepository.save(SUBCLASS_A_EXAMPLE);
+		parentRepository.save(SUBCLASS_A_EXAMPLE_2);
+		parentRepository.save(SUBCLASS_B_EXAMPLE);
+		parentRepository.save(SUBCLASS_B_EXAMPLE_2);
+		parentRepository.flush();
+
+		repository.save(RELATED_PARENT);
+		repository.save(RELATED_PARENT_2);
+		repository.save(RELATED_PARENT_3);
+		repository.save(RELATED_PARENT_4);
+		repository.save(RELATED_PARENT_5);
+		repository.save(RELATED_PARENT_6);
+		repository.flush();
+
+		assertThat(parentRepository.findAll()).hasSize(4).containsExactlyInAnyOrder(SUBCLASS_A_EXAMPLE,
+				SUBCLASS_A_EXAMPLE_2, SUBCLASS_B_EXAMPLE, SUBCLASS_B_EXAMPLE_2);
+
+		assertThat(repository.findAll()).hasSize(6).containsExactlyInAnyOrder(RELATED_PARENT, RELATED_PARENT_2,
+				RELATED_PARENT_3, RELATED_PARENT_4, RELATED_PARENT_5, RELATED_PARENT_6);
+
+	}
+
+	@Test
+	@DisplayName("1. Filter by parent class")
+	@Order(1)
+	void filterByParentClass() {
+
+		QueryFilter<RelatedParent> qf = queryFilterProcessor.newQueryFilter("type=eq:A", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<RelatedParent> list = repository.findAll(qf);
+		assertThat(list).hasSize(3).containsExactlyInAnyOrder(RELATED_PARENT, RELATED_PARENT_2, RELATED_PARENT_5);
+
+		qf = queryFilterProcessor.newQueryFilter("type=eq:B", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(3).containsExactlyInAnyOrder(RELATED_PARENT_3, RELATED_PARENT_4, RELATED_PARENT_6);
+
+	}
+
+	@Test
+	@DisplayName("2. Filter by discriminator class")
+	@Order(2)
+	void filterByDiscriminatorClass() {
+
+		QueryFilter<RelatedParent> qf = queryFilterProcessor.newQueryFilter("discriminatorType=eq:subclassA",
+				QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<RelatedParent> list = repository.findAll(qf);
+		assertThat(list).hasSize(3).containsExactlyInAnyOrder(RELATED_PARENT, RELATED_PARENT_2, RELATED_PARENT_5);
+
+		qf = queryFilterProcessor.newQueryFilter("discriminatorType=eq:subclassB", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(3).containsExactlyInAnyOrder(RELATED_PARENT_3, RELATED_PARENT_4, RELATED_PARENT_6);
+
+	}
+
+	@Test
+	@DisplayName("3. Filter by subclass a field")
+	@Order(3)
+	void filterBySubclassAField() {
+
+		QueryFilter<RelatedParent> qf = queryFilterProcessor.newQueryFilter("subClassAField=eq:Subclass A field",
+				QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		List<RelatedParent> list = repository.findAll(qf);
+		assertThat(list).hasSize(2).containsExactlyInAnyOrder(RELATED_PARENT, RELATED_PARENT_5);
+
+		qf = queryFilterProcessor.newQueryFilter("subClassAField=ne:Subclass A field", QFParamType.RHS_COLON);
+
+		assertThat(qf).isNotNull();
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(1).containsExactlyInAnyOrder(RELATED_PARENT_2);
+
+		qf.deleteField("subClassAField");
+
+		list = repository.findAll(qf);
+		assertThat(list).hasSize(6).containsExactlyInAnyOrder(RELATED_PARENT, RELATED_PARENT_2, RELATED_PARENT_3,
+				RELATED_PARENT_4, RELATED_PARENT_5, RELATED_PARENT_6);
+
+	}
+
+	@Test
+	@DisplayName("END. Test by clear BBDD")
+	@Order(Ordered.LOWEST_PRECEDENCE)
+	void clearBBDD() {
+		repository.deleteAll();
+		assertThat(repository.findAll()).isEmpty();
+
+		parentRepository.deleteAll();
+		assertThat(parentRepository.findAll()).isEmpty();
+	}
+
+}

--- a/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/processor/errors/TestQFProcessorErrors.java
+++ b/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/processor/errors/TestQFProcessorErrors.java
@@ -1,0 +1,43 @@
+package io.github.acoboh.query.filter.jpa.processor.errors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import io.github.acoboh.query.filter.jpa.exceptions.definition.QFDiscriminatorException;
+import io.github.acoboh.query.filter.jpa.filtererrors.discriminator.DiscriminatorFilterErrorDef;
+import io.github.acoboh.query.filter.jpa.model.discriminators.Topic;
+import io.github.acoboh.query.filter.jpa.processor.QFProcessor;
+import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
+
+@SpringJUnitWebConfig(SpringIntegrationTestBase.Config.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class TestQFProcessorErrors {
+
+	@Autowired
+	private ApplicationContext appContext;
+
+	@Test
+	@DisplayName("1. Test QFProcessor Discriminator with not inherited class")
+	void testDiscriminatorNotInherited() {
+
+		QFDiscriminatorException ex = assertThrows(QFDiscriminatorException.class, () -> {
+			new QFProcessor<>(DiscriminatorFilterErrorDef.class, Topic.class, appContext);
+		});
+
+		assertThat(ex.getMessage()).isEqualTo(
+				"Entity class 'class io.github.acoboh.query.filter.jpa.model.discriminators.Topic' is not assignable from value class 'class io.github.acoboh.query.filter.jpa.model.PostBlog'");
+	}
+}

--- a/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/repositories/ParentEntityRepository.java
+++ b/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/repositories/ParentEntityRepository.java
@@ -1,0 +1,14 @@
+package io.github.acoboh.query.filter.jpa.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.ParentEntity;
+
+/**
+ * Parent entity repository
+ */
+public interface ParentEntityRepository
+		extends JpaSpecificationExecutor<ParentEntity>, JpaRepository<ParentEntity, String> {
+
+}

--- a/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/repositories/RelatedParentEntityRepository.java
+++ b/query-filter-jpa/src/test/java/io/github/acoboh/query/filter/jpa/repositories/RelatedParentEntityRepository.java
@@ -1,0 +1,14 @@
+package io.github.acoboh.query.filter.jpa.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import io.github.acoboh.query.filter.jpa.model.discriminators.joined.RelatedParent;
+
+/**
+ * Related parent entity repository
+ */
+public interface RelatedParentEntityRepository
+		extends JpaSpecificationExecutor<RelatedParent>, JpaRepository<RelatedParent, String> {
+
+}


### PR DESCRIPTION
Added new properties to enable matching on nested properties from discriminator entities (#50)

Now you can use the properties `subClassMapping` and `subClassMappingPath` to enable this feature.

Additionally, issues with `@QFDiscriminator` and the`path` property have been fixed and now they work as expected.

> _**NOTE**_:Take care with differences between Hibernate 5 and 6 with the `treat()` method. 

On Hibernate 5, the `subClassMapping` will always do a `INNER JOIN`. On the other hand, on Hibernate 6, if the `subClassMapping` is on the root, it will do a `LEFT JOIN`.