### PR TITLE
Adds join type customization to QF annotations

### DIFF
--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFCollectionElement.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFCollectionElement.java
@@ -8,6 +8,8 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.persistence.criteria.JoinType;
+
 /**
  * Annotation used to define a query filter element that is a collection
  *
@@ -77,4 +79,22 @@ public @interface QFCollectionElement {
 	 * @return path to apply subclass scanning
 	 */
 	String subClassMappingPath() default "";
+
+	/**
+	 * Select the join type to use on the query.
+	 *
+	 * <p>
+	 * If you only specify one join type, it will be used for all joins.
+	 * <p>
+	 * If you specify multiple join types, and there are multiple joins, il will use
+	 * the first join type for the first until the latest is reached, and it will be
+	 * used for the rest.
+	 * <p>
+	 * Example: If you specify {@code JoinType.LEFT, JoinType.INNER}, the first join
+	 * will be a LEFT join, the second will be an INNER join, and all the rest will
+	 * be INNER joins.
+	 *
+	 * @return join type to use
+	 */
+	JoinType[] joinTypes() default {JoinType.INNER};
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFDiscriminator.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFDiscriminator.java
@@ -7,6 +7,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.persistence.criteria.JoinType;
+
 /**
  * Special query filter element to filter between Discriminator types
  *
@@ -61,5 +63,23 @@ public @interface QFDiscriminator {
 		Class<?> type();
 
 	}
+
+	/**
+	 * Select the join type to use on the query.
+	 *
+	 * <p>
+	 * If you only specify one join type, it will be used for all joins.
+	 * <p>
+	 * If you specify multiple join types, and there are multiple joins, il will use
+	 * the first join type for the first until the latest is reached, and it will be
+	 * used for the rest.
+	 * <p>
+	 * Example: If you specify {@code JoinType.LEFT, JoinType.INNER}, the first join
+	 * will be a LEFT join, the second will be an INNER join, and all the rest will
+	 * be INNER joins.
+	 *
+	 * @return join type to use
+	 */
+	JoinType[] joinTypes() default {JoinType.INNER};
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFElement.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFElement.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import io.github.acoboh.query.filter.jpa.operations.QFOperationEnum;
+import jakarta.persistence.criteria.JoinType;
 
 /**
  * Annotation used to define the query filter param filter.
@@ -195,5 +196,23 @@ public @interface QFElement {
 	 * @return path to apply subclass scanning
 	 */
 	String subClassMappingPath() default "";
+
+	/**
+	 * Select the join type to use on the query.
+	 * 
+	 * <p>
+	 * If you only specify one join type, it will be used for all joins.
+	 * <p>
+	 * If you specify multiple join types, and there are multiple joins, il will use
+	 * the first join type for the first until the latest is reached, and it will be
+	 * used for the rest.
+	 * <p>
+	 * Example: If you specify {@code JoinType.LEFT, JoinType.INNER}, the first join
+	 * will be a LEFT join, the second will be an INNER join, and all the rest will
+	 * be INNER joins.
+	 * 
+	 * @return join type to use
+	 */
+	JoinType[] joinTypes() default {JoinType.INNER};
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFJsonElement.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFJsonElement.java
@@ -8,6 +8,8 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.persistence.criteria.JoinType;
+
 /**
  * Special query filter element used on JSON elements
  *
@@ -49,5 +51,23 @@ public @interface QFJsonElement {
 	 * @return true if case-sensitive
 	 */
 	boolean caseSensitive() default false;
+
+	/**
+	 * Select the join type to use on the query.
+	 *
+	 * <p>
+	 * If you only specify one join type, it will be used for all joins.
+	 * <p>
+	 * If you specify multiple join types, and there are multiple joins, il will use
+	 * the first join type for the first until the latest is reached, and it will be
+	 * used for the rest.
+	 * <p>
+	 * Example: If you specify {@code JoinType.LEFT, JoinType.INNER}, the first join
+	 * will be a LEFT join, the second will be an INNER join, and all the rest will
+	 * be INNER joins.
+	 *
+	 * @return join type to use
+	 */
+	JoinType[] joinTypes() default {JoinType.INNER};
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFSortable.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFSortable.java
@@ -6,6 +6,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.persistence.criteria.JoinType;
+
 /**
  * Query filter annotation to mark field as sortable
  *
@@ -28,4 +30,22 @@ public @interface QFSortable {
 	 * @return true if enabled
 	 */
 	boolean autoFetch() default true;
+
+	/**
+	 * Select the join type to use on the query.
+	 *
+	 * <p>
+	 * If you only specify one join type, it will be used for all joins.
+	 * <p>
+	 * If you specify multiple join types, and there are multiple joins, il will use
+	 * the first join type for the first until the latest is reached, and it will be
+	 * used for the rest.
+	 * <p>
+	 * Example: If you specify {@code JoinType.LEFT, JoinType.INNER}, the first join
+	 * will be a LEFT join, the second will be an INNER join, and all the rest will
+	 * be INNER joins.
+	 *
+	 * @return join type to use
+	 */
+	JoinType[] joinTypes() default {JoinType.INNER};
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QFAttribute.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QFAttribute.java
@@ -20,7 +20,7 @@ public class QFAttribute {
 		}
 
 		Class<?> javaType = attribute.getJavaType();
-		this.isEnum = (Boolean) (javaType.isEnum() || Enum.class.isAssignableFrom(javaType));
+		this.isEnum = (javaType.isEnum() || Enum.class.isAssignableFrom(javaType));
 	}
 
 	public Attribute<?, ?> getAttribute() {

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QueryFilter.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QueryFilter.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.util.Pair;
+import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -855,7 +856,7 @@ public class QueryFilter<E> implements Specification<E> {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Predicate toPredicate(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
+	public Predicate toPredicate(@NonNull Root<E> root, CriteriaQuery<?> query, @NonNull CriteriaBuilder criteriaBuilder) {
 
 		Map<String, List<Predicate>> predicatesMap = new HashMap<>();
 		Map<String, Path<?>> pathsMap = new HashMap<>();

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
@@ -4,11 +4,15 @@ import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.github.acoboh.query.filter.jpa.annotations.QFBlockParsing;
 import io.github.acoboh.query.filter.jpa.annotations.QFCollectionElement;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QFCollectionNotSupported;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
 import io.github.acoboh.query.filter.jpa.processor.QFAttribute;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.metamodel.Metamodel;
 
 /**
@@ -16,7 +20,10 @@ import jakarta.persistence.metamodel.Metamodel;
  */
 public class QFDefinitionCollection extends QFAbstractDefinition {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(QFDefinitionCollection.class);
+
 	private final List<QFAttribute> attributes;
+	private final List<JoinType> joinTypes;
 
 	QFDefinitionCollection(Field filterField, Class<?> filterClass, Class<?> entityClass, QFBlockParsing blockParsing,
 			QFCollectionElement collectionElement, Metamodel metamodel) throws QueryFilterDefinitionException {
@@ -35,6 +42,13 @@ public class QFDefinitionCollection extends QFAbstractDefinition {
 			throw new QFCollectionNotSupported(filterName, filterClass, fieldClassProcessor.getFinalClass());
 		}
 
+		if (collectionElement.joinTypes().length == 0) {
+			LOGGER.debug("No join types defined for collection {}. Using default INNER", filterName);
+			this.joinTypes = List.of(JoinType.INNER);
+		} else {
+			this.joinTypes = List.of(collectionElement.joinTypes());
+		}
+
 	}
 
 	/**
@@ -44,6 +58,15 @@ public class QFDefinitionCollection extends QFAbstractDefinition {
 	 */
 	public List<QFAttribute> getPaths() {
 		return attributes;
+	}
+
+	/**
+	 * Get join types of the collection
+	 *
+	 * @return join types
+	 */
+	public List<JoinType> getJoinTypes() {
+		return joinTypes;
 	}
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
@@ -6,11 +6,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.github.acoboh.query.filter.jpa.annotations.QFBlockParsing;
 import io.github.acoboh.query.filter.jpa.annotations.QFDiscriminator;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QFDiscriminatorException;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
 import io.github.acoboh.query.filter.jpa.processor.QFAttribute;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.metamodel.Metamodel;
 
 /**
@@ -18,8 +22,11 @@ import jakarta.persistence.metamodel.Metamodel;
  */
 public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(QFDefinitionDiscriminator.class);
+
 	private final QFDiscriminator discriminatorAnnotation;
 	private final List<QFAttribute> attributes;
+	private final List<JoinType> joinTypes;
 	private final Class<?> finalClass;
 
 	private final Map<String, Class<?>> discriminatorMap = new HashMap<>();
@@ -58,6 +65,13 @@ public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 			discriminatorMap.put(value.name(), value.type());
 		}
 
+		if (discriminatorAnnotation.joinTypes().length == 0) {
+			LOGGER.warn("No join types defined for discriminator {}. Defaulting to INNER", filterName);
+			this.joinTypes = List.of(JoinType.INNER);
+		} else {
+			this.joinTypes = List.of(discriminatorAnnotation.joinTypes());
+		}
+
 	}
 
 	/**
@@ -94,6 +108,15 @@ public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 	 */
 	public Map<String, Class<?>> getDiscriminatorMap() {
 		return discriminatorMap;
+	}
+
+	/**
+	 * Get the join types
+	 *
+	 * @return join types
+	 */
+	public List<JoinType> getJoinTypes() {
+		return joinTypes;
 	}
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
@@ -5,11 +5,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.github.acoboh.query.filter.jpa.annotations.QFBlockParsing;
 import io.github.acoboh.query.filter.jpa.annotations.QFSortable;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
 import io.github.acoboh.query.filter.jpa.processor.QFAttribute;
 import io.github.acoboh.query.filter.jpa.processor.definitions.traits.IDefinitionSortable;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.metamodel.Metamodel;
 
 /**
@@ -17,11 +21,14 @@ import jakarta.persistence.metamodel.Metamodel;
  */
 public class QFDefinitionSortable extends QFAbstractDefinition implements IDefinitionSortable {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(QFDefinitionSortable.class);
+
 	private final List<List<QFAttribute>> attributes;
 
 	private final boolean autoFetch;
 
 	private final List<String> fullPath;
+	private final List<JoinType> joinTypes;
 
 	QFDefinitionSortable(Field filterField, Class<?> filterClass, Class<?> entityClass, QFBlockParsing blockParsing,
 			QFSortable sortableAnnotation, Metamodel metamodel) throws QueryFilterDefinitionException {
@@ -36,6 +43,13 @@ public class QFDefinitionSortable extends QFAbstractDefinition implements IDefin
 		autoFetch = sortableAnnotation.autoFetch();
 
 		this.fullPath = Collections.singletonList(sortableAnnotation.value());
+
+		if (sortableAnnotation.joinTypes().length == 0) {
+			LOGGER.warn("Join types are empty for field {}. Defaulting to INNER", filterField.getName());
+			joinTypes = List.of(JoinType.INNER);
+		} else {
+			joinTypes = List.of(sortableAnnotation.joinTypes());
+		}
 
 	}
 
@@ -57,5 +71,10 @@ public class QFDefinitionSortable extends QFAbstractDefinition implements IDefin
 	@Override
 	public List<String> getPathField() {
 		return fullPath;
+	}
+
+	@Override
+	public List<JoinType> getJoinTypes(int index) {
+		return joinTypes;
 	}
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/traits/IDefinitionSortable.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/traits/IDefinitionSortable.java
@@ -3,6 +3,7 @@ package io.github.acoboh.query.filter.jpa.processor.definitions.traits;
 import java.util.List;
 
 import io.github.acoboh.query.filter.jpa.processor.QFAttribute;
+import jakarta.persistence.criteria.JoinType;
 
 /**
  * Sortable interface
@@ -45,5 +46,14 @@ public interface IDefinitionSortable {
 	 * @return full path field
 	 */
 	List<String> getPathField();
+
+	/**
+	 * Get the join types
+	 *
+	 * @param index
+	 *            of path
+	 * @return join types
+	 */
+	List<JoinType> getJoinTypes(int index);
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFCollectionMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFCollectionMatch.java
@@ -81,8 +81,8 @@ public class QFCollectionMatch implements QFSpecificationPart {
 			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
 			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass) {
 
-		Path<?> expressionPath = QueryUtils.getObject(root, definition.getPaths(), pathsMap, true, false,
-				criteriaBuilder);
+		Path<?> expressionPath = QueryUtils.getObject(root, definition.getPaths(), definition.getJoinTypes(), pathsMap,
+				true, false, criteriaBuilder);
 
 		Expression<? extends java.util.Collection<?>> expression;
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFDiscriminatorMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFDiscriminatorMatch.java
@@ -153,7 +153,8 @@ public class QFDiscriminatorMatch implements QFSpecificationPart {
 		if (isRoot) {
 			expression = root.type();
 		} else {
-			expression = QueryUtils.getObject(root, path, pathsMap, false, false, criteriaBuilder).type();
+			expression = QueryUtils
+					.getObject(root, path, definition.getJoinTypes(), pathsMap, false, false, criteriaBuilder).type();
 		}
 
 		predicatesMap.computeIfAbsent(definition.getFilterName(), t -> new ArrayList<>()).add(operation

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFElementMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFElementMatch.java
@@ -275,7 +275,7 @@ public class QFElementMatch implements QFSpecificationPart {
 	/**
 	 * Get if the matching element must be evaluated
 	 *
-	 * @return true if must to be evaluated
+	 * @return true if it must be evaluated
 	 */
 	public boolean needToEvaluate() {
 		if (!initialized) {
@@ -466,9 +466,8 @@ public class QFElementMatch implements QFSpecificationPart {
 		List<Predicate> predicates = new ArrayList<>();
 
 		for (var path : paths) {
-			predicates.add(operation.generatePredicate(
-					QueryUtils.getObject(root, path, pathsMap, false, false, criteriaBuilder), criteriaBuilder, this,
-					index, mlmap));
+			predicates.add(operation.generatePredicate(QueryUtils.getObject(root, path, definition.getJoinTypes(index),
+					pathsMap, false, false, criteriaBuilder), criteriaBuilder, this, index, mlmap));
 			index++;
 		}
 
@@ -496,7 +495,8 @@ public class QFElementMatch implements QFSpecificationPart {
 
 			subquery.select(newRoot);
 
-			Path<?> pathFinal = QueryUtils.getObject(newRoot, path, subSelecthMap, false, false, criteriaBuilder);
+			Path<?> pathFinal = QueryUtils.getObject(newRoot, path, definition.getJoinTypes(index), subSelecthMap,
+					false, false, criteriaBuilder);
 
 			QFOperationEnum op = operation;
 			if (op == QFOperationEnum.NOT_EQUAL) {

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFJsonElementMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFJsonElementMatch.java
@@ -170,9 +170,8 @@ public class QFJsonElementMatch implements QFSpecificationPart {
 			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass) {
 
 		predicatesMap.computeIfAbsent(definition.getFilterName(), t -> new ArrayList<>())
-				.add(operation.generateJsonPredicate(
-						QueryUtils.getObject(root, definition.getAttributes(), pathsMap, true, false, criteriaBuilder),
-						criteriaBuilder, this));
+				.add(operation.generateJsonPredicate(QueryUtils.getObject(root, definition.getAttributes(),
+						definition.getJoinTypes(), pathsMap, true, false, criteriaBuilder), criteriaBuilder, this));
 
 	}
 

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterBlogJoinType.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterBlogJoinType.java
@@ -1,0 +1,13 @@
+package io.github.acoboh.query.filter.jpa.domain;
+
+import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
+import io.github.acoboh.query.filter.jpa.annotations.QFElement;
+import io.github.acoboh.query.filter.jpa.model.PostBlog;
+import jakarta.persistence.criteria.JoinType;
+
+@QFDefinitionClass(PostBlog.class)
+public class FilterBlogJoinType {
+
+	@QFElement(value = "comments.author", joinTypes = JoinType.LEFT)
+	private String commentAuthor;
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/BasicTest.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/BasicTest.java
@@ -48,18 +48,10 @@ class BasicTest {
 		POST_EXAMPLE.setText("text");
 		POST_EXAMPLE.setAvgNote(2.5d);
 		POST_EXAMPLE.setLikes(100);
-		POST_EXAMPLE.setCreateDate(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)); // Truncated to avoid rounding
-																						// issues with Java > 8 and BBDD
-		POST_EXAMPLE.setLastTimestamp(Timestamp.valueOf(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS))); // Truncated
-																												// to
-																												// avoid
-																												// rounding
-																												// issues
-																												// with
-																												// Java
-																												// > 8
-																												// and
-																												// BBDD
+		// Truncated to avoid rounding issues with Java > 8 and BBDD
+		POST_EXAMPLE.setCreateDate(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS));
+		POST_EXAMPLE.setLastTimestamp(Timestamp.valueOf(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)));
+
 		POST_EXAMPLE.setPublished(true);
 		POST_EXAMPLE.setPostType(PostBlog.PostType.TEXT);
 	}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/JoinTypesElementTest.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/JoinTypesElementTest.java
@@ -1,0 +1,115 @@
+package io.github.acoboh.query.filter.jpa.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import io.github.acoboh.query.filter.jpa.domain.FilterBlogJoinType;
+import io.github.acoboh.query.filter.jpa.model.Comments;
+import io.github.acoboh.query.filter.jpa.model.PostBlog;
+import io.github.acoboh.query.filter.jpa.repositories.PostBlogRepository;
+import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
+
+/**
+ * Join types element test
+ *
+ * @author Adrián Cobo
+ */
+@SpringJUnitWebConfig(SpringIntegrationTestBase.Config.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class JoinTypesElementTest {
+
+	private static final PostBlog POST_EXAMPLE = new PostBlog();
+	private static final PostBlog POST_EXAMPLE_2 = new PostBlog();
+	private static final Comments COMMENT_EXAMPLE = new Comments();
+
+	static {
+		POST_EXAMPLE.setUuid(UUID.randomUUID());
+		POST_EXAMPLE.setAuthor("author 1");
+		POST_EXAMPLE.setText("text 1");
+		POST_EXAMPLE.setAvgNote(2.5d);
+		POST_EXAMPLE.setLikes(100);
+		POST_EXAMPLE.setCreateDate(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS));
+		POST_EXAMPLE.setLastTimestamp(Timestamp.valueOf(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)));
+
+		COMMENT_EXAMPLE.setId(1);
+		COMMENT_EXAMPLE.setAuthor("author");
+		COMMENT_EXAMPLE.setPostBlog(POST_EXAMPLE);
+
+		POST_EXAMPLE.setComments(Set.of(COMMENT_EXAMPLE));
+
+		POST_EXAMPLE_2.setUuid(UUID.randomUUID());
+		POST_EXAMPLE_2.setAuthor("author 2");
+		POST_EXAMPLE_2.setText("text 2");
+		POST_EXAMPLE_2.setAvgNote(2.5d);
+		POST_EXAMPLE_2.setLikes(100);
+		POST_EXAMPLE_2.setCreateDate(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS));
+		POST_EXAMPLE_2.setLastTimestamp(Timestamp.valueOf(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)));
+	}
+
+	@Autowired
+	private QFProcessor<FilterBlogJoinType, PostBlog> queryFilterProcessor;
+
+	@Autowired
+	private PostBlogRepository repository;
+
+	@Test
+	@DisplayName("0. Setup")
+	@Order(1)
+	void setup() {
+
+		assertThat(queryFilterProcessor).isNotNull();
+		assertThat(repository).isNotNull();
+
+		assertThat(repository.findAll()).isEmpty();
+
+		repository.saveAndFlush(POST_EXAMPLE);
+		repository.saveAndFlush(POST_EXAMPLE_2);
+	}
+
+	@Test
+	@DisplayName("1. Test join types return only the first data")
+	@Order(2)
+	void testJoinTypes() {
+
+		// Filter
+		String filter = "comments.author=author and comments.likes=1";
+
+		// Execute
+		var qf = queryFilterProcessor.newQueryFilter("commentAuthor=null:true", QFParamType.RHS_COLON);
+
+		var result = repository.findAll(qf);
+
+		assertThat(result).isNotNull();
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isEqualTo(POST_EXAMPLE_2);
+
+	}
+
+	@Test
+	@DisplayName("END. Test by clear BBDD")
+	@Order(Ordered.LOWEST_PRECEDENCE)
+	void clearBBDD() {
+		repository.deleteAll();
+		assertThat(repository.findAll()).isEmpty();
+	}
+
+}


### PR DESCRIPTION
Allows users to specify join types (INNER, LEFT, RIGHT) for relationships in query filter annotations. This provides more control over query generation and addresses potential performance issues related to default join strategies.