### PR TITLE
Improves query filter flexibility and error handling

### DIFF
--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/advisor/QFExceptionAdvisor.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/advisor/QFExceptionAdvisor.java
@@ -29,6 +29,7 @@ import jakarta.servlet.http.HttpServletRequest;
 public class QFExceptionAdvisor {
 
 	private final ResourceBundleMessageSource messageSource;
+	private final boolean extendErrorMessage;
 
 	/**
 	 * Default constructor
@@ -43,6 +44,8 @@ public class QFExceptionAdvisor {
 		messageSource.setBasename(props.getMessageSourceBaseName());
 		messageSource.setDefaultEncoding(props.getMessageSourceDefaultEncoding());
 		messageSource.setUseCodeAsDefaultMessage(props.isMessageSourceUseCodeAsDefaultMessage());
+
+		extendErrorMessage = props.isExtendErrorMessage();
 	}
 
 	/**
@@ -62,7 +65,7 @@ public class QFExceptionAdvisor {
 	private ResponseEntity<Object> handleAdvisorMessageResolver(ExceptionLanguageResolver resolver, Exception ex,
 			HttpServletRequest request) {
 		String message = message(resolver.getMessageCode(), resolver.getArguments());
-		return defaultErrorMessage(ex, request, resolver.getHttpStatus(), message, false);
+		return defaultErrorMessage(ex, request, resolver.getHttpStatus(), message, extendErrorMessage);
 	}
 
 	private ResponseEntity<Object> defaultErrorMessage(Exception e, HttpServletRequest request, HttpStatus status,

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFCollectionElement.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFCollectionElement.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import io.github.acoboh.query.filter.jpa.operations.QFCollectionOperationEnum;
 import jakarta.persistence.criteria.JoinType;
 
 /**
@@ -97,4 +98,13 @@ public @interface QFCollectionElement {
 	 * @return join type to use
 	 */
 	JoinType[] joinTypes() default {JoinType.INNER};
+
+	/**
+	 * List of allowed operations for this element
+	 * <p>
+	 * If the allowed operations are not specified, all operations will be allowed.
+	 *
+	 * @return array of allowed operations
+	 */
+	QFCollectionOperationEnum[] allowedOperations() default {};
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFDiscriminator.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFDiscriminator.java
@@ -7,6 +7,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import io.github.acoboh.query.filter.jpa.operations.QFOperationDiscriminatorEnum;
 import jakarta.persistence.criteria.JoinType;
 
 /**
@@ -81,5 +82,14 @@ public @interface QFDiscriminator {
 	 * @return join type to use
 	 */
 	JoinType[] joinTypes() default {JoinType.INNER};
+
+	/**
+	 * List of allowed operations for this element
+	 * <p>
+	 * If the allowed operations are not specified, all operations will be allowed.
+	 *
+	 * @return array of allowed operations
+	 */
+	QFOperationDiscriminatorEnum[] allowedOperations() default {};
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFElement.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFElement.java
@@ -215,4 +215,17 @@ public @interface QFElement {
 	 */
 	JoinType[] joinTypes() default {JoinType.INNER};
 
+	/**
+	 * List of allowed operations for this element
+	 * <p>
+	 * If the allowed operations are not specified, all operations will be allowed.
+	 * <p>
+	 * If the field is annotated with {@link QFElements}, the allowed operations
+	 * will be applied to all elements defined in the {@link #value()} attribute and
+	 * the configuration of the {@link QFElement} will be ignored.
+	 *
+	 * @return array of allowed operations
+	 */
+	QFOperationEnum[] allowedOperations() default {};
+
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFElements.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFElements.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import io.github.acoboh.query.filter.jpa.operations.QFOperationEnum;
 import io.github.acoboh.query.filter.jpa.predicate.PredicateOperation;
 
 /**
@@ -33,4 +34,18 @@ public @interface QFElements {
 	 * @return operation selected
 	 */
 	PredicateOperation operation() default PredicateOperation.AND;
+
+	/**
+	 * List of allowed operations for this element
+	 * <p>
+	 * If the allowed operations are not specified, all operations will be allowed.
+	 * 
+	 * <p>
+	 * When using this annotation, the allowed operations will be applied to all
+	 * elements defined in the {@link #value()} attribute and the configuration of
+	 * the {@link QFElement} will be ignored.
+	 *
+	 * @return array of allowed operations
+	 */
+	QFOperationEnum[] allowedOperations() default {};
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFJsonElement.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/annotations/QFJsonElement.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import io.github.acoboh.query.filter.jpa.operations.QFOperationJsonEnum;
 import jakarta.persistence.criteria.JoinType;
 
 /**
@@ -69,5 +70,14 @@ public @interface QFJsonElement {
 	 * @return join type to use
 	 */
 	JoinType[] joinTypes() default {JoinType.INNER};
+
+	/**
+	 * List of allowed operations for this element
+	 * <p>
+	 * If the allowed operations are not specified, all operations will be allowed.
+	 *
+	 * @return array of allowed operations
+	 */
+	QFOperationJsonEnum[] allowedOperations() default {};
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/config/QFBeanFactoryPostProcessor.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/config/QFBeanFactoryPostProcessor.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -37,7 +36,6 @@ import org.springframework.util.ClassUtils;
 
 import io.github.acoboh.query.filter.jpa.annotations.EnableQueryFilter;
 import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
-import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
 import io.github.acoboh.query.filter.jpa.processor.QFProcessor;
 
 /**
@@ -167,17 +165,12 @@ public class QFBeanFactoryPostProcessor implements ApplicationContextAware, Bean
 		Set<Class<?>> classSet = getClassAnnotatedWithQFDef(packagesToAnalyze);
 
 		for (Class<?> cl : classSet) {
-			try {
-				registerQueryFilterClass(cl, beanFactory);
-			} catch (QueryFilterDefinitionException e) {
-				throw new BeanCreationException("Error creating bean query filter for class " + cl.getName(), e);
-			}
+			registerQueryFilterClass(cl, beanFactory);
 		}
 
 	}
 
-	private void registerQueryFilterClass(Class<?> cl, ConfigurableListableBeanFactory beanFactory)
-			throws QueryFilterDefinitionException {
+	private void registerQueryFilterClass(Class<?> cl, ConfigurableListableBeanFactory beanFactory) {
 
 		String beanName = cl.getName() + "queryFilterBean";
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/converters/QFCustomConverter.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/converters/QFCustomConverter.java
@@ -10,6 +10,7 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.data.util.Pair;
+import org.springframework.lang.NonNull;
 
 import io.github.acoboh.query.filter.jpa.annotations.QFParam;
 import io.github.acoboh.query.filter.jpa.processor.QFProcessor;
@@ -62,7 +63,7 @@ public class QFCustomConverter implements GenericConverter {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+	public Object convert(Object source, @NonNull TypeDescriptor sourceType, @NonNull TypeDescriptor targetType) {
 
 		if (source.getClass() == QFProcessor.class) {
 			return source;

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/exceptions/QFOperationNotAllowed.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/exceptions/QFOperationNotAllowed.java
@@ -1,0 +1,51 @@
+package io.github.acoboh.query.filter.jpa.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public class QFOperationNotAllowed extends QueryFilterException {
+
+	private final String field;
+	private final String operation;
+
+	private final transient Object[] arguments;
+
+	public QFOperationNotAllowed(String field, String operation) {
+		super("The operation '{}' is not allowed for the field '{}'", operation, field);
+		this.field = field;
+		this.operation = operation;
+		this.arguments = new Object[]{operation, field};
+	}
+
+	/**
+	 * Get field
+	 *
+	 * @return field
+	 */
+	public String getField() {
+		return field;
+	}
+
+	/**
+	 * Get operation
+	 *
+	 * @return operation
+	 */
+	public String getOperation() {
+		return operation;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.FORBIDDEN;
+	}
+
+	@Override
+	public Object[] getArguments() {
+		return arguments;
+	}
+
+	@Override
+	public String getMessageCode() {
+		return "qf.exceptions.operation-not-allowed";
+	}
+}

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/exceptions/definition/QueryFilterDefinitionException.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/exceptions/definition/QueryFilterDefinitionException.java
@@ -22,7 +22,7 @@ public class QueryFilterDefinitionException extends Exception {
 	 * @param args
 	 *            arguments
 	 */
-	protected QueryFilterDefinitionException(String message, Object... args) {
+	public QueryFilterDefinitionException(String message, Object... args) {
 		super(MessageFormatter.arrayFormat(message, args).getMessage());
 	}
 
@@ -36,7 +36,7 @@ public class QueryFilterDefinitionException extends Exception {
 	 * @param args
 	 *            arguments
 	 */
-	protected QueryFilterDefinitionException(String message, Throwable cause, Object... args) {
+	public QueryFilterDefinitionException(String message, Throwable cause, Object... args) {
 		super(MessageFormatter.arrayFormat(message, args).getMessage(), cause);
 	}
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/predicate/PredicateLevel.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/predicate/PredicateLevel.java
@@ -47,7 +47,7 @@ class PredicateLevel {
 
 		if (parts.size() == 1) {
 			LOGGER.debug("Parts has size 1, must be simplified");
-			levelParts.add(parts.get(0).getPart());
+			levelParts.add(parts.get(0).part());
 
 			return;
 		}
@@ -58,10 +58,10 @@ class PredicateLevel {
 			LOGGER.trace("Parsing parts {}", part);
 
 			if (i % 2 == 1) {
-				LOGGER.trace("Parsing part as operator {}", part.getPart());
-				PredicateOperation operator = PredicateOperation.getOperator(part.getPart());
+				LOGGER.trace("Parsing part as operator {}", part.part());
+				PredicateOperation operator = PredicateOperation.getOperator(part.part());
 				if (operator == null) {
-					LOGGER.error("Unexpected part {}. Must be an operator", part.getPart());
+					LOGGER.error("Unexpected part {}. Must be an operator", part.part());
 					throw new IllegalStateException("Unexpected part. Must be an operator");
 				}
 
@@ -74,10 +74,10 @@ class PredicateLevel {
 					throw new IllegalStateException("Mixed operators on same level");
 				}
 			} else {
-				if (part.isNested()) {
+				if (part.nested()) {
 					LOGGER.trace("Parsing nested level as new predicate");
 
-					PredicateLevel nestedLevel = new PredicateLevel(part.getPart(), fullMap);
+					PredicateLevel nestedLevel = new PredicateLevel(part.part(), fullMap);
 					switch (nestedLevel.parts.size()) {
 						case 0 :
 							LOGGER.trace("Nested level is empty. Ignore them");
@@ -97,12 +97,12 @@ class PredicateLevel {
 
 				} else {
 
-					if (!fullMap.containsKey(part.getPart())) {
-						LOGGER.error("Error missing part {} on definition map", part.getPart());
+					if (!fullMap.containsKey(part.part())) {
+						LOGGER.error("Error missing part {} on definition map", part.part());
 						throw new IllegalStateException("Missing part on definition map");
 					}
 
-					levelParts.add(part.getPart());
+					levelParts.add(part.part());
 
 				}
 			}

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/predicate/PredicatePart.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/predicate/PredicatePart.java
@@ -7,11 +7,7 @@ import org.springframework.util.Assert;
  *
  * @author Adrián Cobo
  */
-public class PredicatePart {
-
-	private final String part;
-
-	private final boolean nested;
+public record PredicatePart(String part, boolean nested) {
 
 	/**
 	 * Create a new predicate part
@@ -21,27 +17,8 @@ public class PredicatePart {
 	 * @param nested
 	 *            if it is nested
 	 */
-	public PredicatePart(String part, boolean nested) {
+	public PredicatePart {
 		Assert.notNull(part, "Predicate part cannot be null");
-		this.part = part;
-		this.nested = nested;
 	}
 
-	/**
-	 * Get the predicate part
-	 *
-	 * @return predicate part
-	 */
-	public String getPart() {
-		return part;
-	}
-
-	/**
-	 * Get if it is nested
-	 *
-	 * @return if it is nested
-	 */
-	public boolean isNested() {
-		return nested;
-	}
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/predicate/PredicateProcessorResolutor.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/predicate/PredicateProcessorResolutor.java
@@ -100,8 +100,7 @@ public class PredicateProcessorResolutor {
 					LOGGER.trace("Using surrounding level as final filter");
 
 					toAdd.add(res);
-					Predicate surrounding = defaultOperation.getPredicate(criteriaBuilder, toAdd);
-					res = surrounding;
+					res = defaultOperation.getPredicate(criteriaBuilder, toAdd);
 
 				}
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QFSpecificationPart.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QFSpecificationPart.java
@@ -42,7 +42,8 @@ public interface QFSpecificationPart {
 	 */
 	<E> void processPart(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder,
 			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
-			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass);
+			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass,
+			boolean isCount);
 
 	/**
 	 * Get definition of the filter field

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QFSpecificationPart.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QFSpecificationPart.java
@@ -7,11 +7,8 @@ import org.springframework.util.MultiValueMap;
 
 import io.github.acoboh.query.filter.jpa.processor.definitions.QFAbstractDefinition;
 import io.github.acoboh.query.filter.jpa.spel.SpelResolverContext;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
 
 /**
  * Interface to create all parts of the final specification
@@ -23,12 +20,6 @@ public interface QFSpecificationPart {
 	 *
 	 * @param <E>
 	 *            Entity class
-	 * @param root
-	 *            Root
-	 * @param query
-	 *            Query
-	 * @param criteriaBuilder
-	 *            Criteria builder
 	 * @param predicatesMap
 	 *            Map of predicates
 	 * @param pathsMap
@@ -40,10 +31,9 @@ public interface QFSpecificationPart {
 	 * @param entityClass
 	 *            Entity class
 	 */
-	<E> void processPart(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder,
-			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
-			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass,
-			boolean isCount);
+	<E> void processPart(QueryInfo<E> queryInfo, Map<String, List<Predicate>> predicatesMap,
+			Map<String, Path<?>> pathsMap, MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver,
+			Class<E> entityClass);
 
 	/**
 	 * Get definition of the filter field

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QueryInfo.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/QueryInfo.java
@@ -1,0 +1,10 @@
+package io.github.acoboh.query.filter.jpa.processor;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import jakarta.validation.constraints.NotNull;
+
+public record QueryInfo<E>(@NotNull Root<E> root, CriteriaQuery<?> query, @NotNull CriteriaBuilder cb,
+		boolean isCount) {
+}

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/FieldClassProcessor.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/FieldClassProcessor.java
@@ -10,7 +10,6 @@ import org.springframework.util.Assert;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QFElementException;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
 import io.github.acoboh.query.filter.jpa.processor.QFAttribute;
-import io.github.acoboh.query.filter.jpa.utils.ClassUtils;
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.ManagedType;
 import jakarta.persistence.metamodel.Metamodel;
@@ -24,108 +23,22 @@ class FieldClassProcessor {
 
 	private final Class<?> rootClass;
 	private final String pathField;
-	private final boolean checkFinal;
 	private final Metamodel metamodel;
-	// private List<QFPath> paths;
 	private List<QFAttribute> attributes;
 	private Class<?> finalClass;
 
 	private final Class<?> subclassMapping;
 	private final String subClassMappingPath;
 
-	FieldClassProcessor(Class<?> rootClass, String pathField, boolean checkFinal, Class<?> subclassMapping,
+	FieldClassProcessor(Class<?> rootClass, String pathField, Class<?> subclassMapping,
 			String subClassMappingPath, Metamodel metamodel) {
 		Assert.notNull(pathField, "Path field cannot be null");
 		this.rootClass = rootClass;
 		this.pathField = pathField;
-		this.checkFinal = checkFinal;
 		this.subclassMapping = subclassMapping;
 		this.subClassMappingPath = subClassMappingPath;
 		this.metamodel = metamodel;
 	}
-
-// @formatter:off
-//	    public List<QFPath> getPaths() throws QueryFilterDefinitionException {
-//		if (paths != null) {
-//			return paths;
-//		}
-//
-//		paths = new ArrayList<>();
-//
-//		String[] splitLevel = pathField.split("\\.");
-//		if (splitLevel.length == 0) {
-//			throw new QFElementException(pathField, rootClass);
-//		}
-//
-//		String[] levelsSubClass = null;
-//
-//		if (subclassMapping != null && !Void.class.equals(subclassMapping)) {
-//			LOGGER.trace("Processing subclass mapping {}", subclassMapping);
-//			if (subClassMappingPath != null && !subClassMappingPath.isEmpty()
-//					&& !pathField.startsWith(subClassMappingPath)) {
-//				LOGGER.trace("Subclass mapping path '{}' not present in path field '{}'", subClassMappingPath,
-//						pathField);
-//				throw new QFElementException(pathField, subclassMapping);
-//			}
-//			if (subClassMappingPath.isEmpty()) {
-//				levelsSubClass = new String[0];
-//			} else {
-//				levelsSubClass = subClassMappingPath.split("\\.");
-//			}
-//
-//		}
-//
-//		Class<?> levelClass = rootClass;
-//
-//		int actualLevel = -1;
-//		for (String level : splitLevel) {
-//			Class<?> treatClass = null;
-//			actualLevel++;
-//
-//			LOGGER.trace("Processing level {}", level);
-//
-//			if (levelsSubClass != null && levelsSubClass.length == actualLevel) {
-//				// Check levelClass is parent of subclassMapping
-//				if (!levelClass.isAssignableFrom(subclassMapping)) {
-//					throw new QFElementException(pathField, subclassMapping);
-//				}
-//				treatClass = subclassMapping;
-//				levelClass = subclassMapping;
-//			}
-//
-//			Field fieldObject = ClassUtils.getDeclaredFieldSuperclass(levelClass, level);
-//			if (fieldObject == null) {
-//				throw new QFElementException(pathField, levelClass);
-//			}
-//
-//			QFPath path = createQPathOfField(fieldObject, level, treatClass);
-//			paths.add(path);
-//
-//			// Check path is final and nested levels are present
-//			if (path.isFinal() && splitLevel.length != paths.size()) {
-//				throw new QFFieldLevelException(pathField, level);
-//			}
-//
-//			// Final iteration. Double check final class
-//			if (splitLevel.length == paths.size() && !path.isFinal()) {
-//				path.setFinal(couldBeFinal(path.getFieldClass()));
-//			}
-//
-//			levelClass = path.getFieldClass();
-//
-//		}
-//
-//		// Final check
-//		if (checkFinal && !paths.get(paths.size() - 1).isFinal()) {
-//			throw new QFFieldLevelException(pathField, splitLevel[splitLevel.length - 1]);
-//		}
-//
-//		finalClass = levelClass;
-//
-//		return paths;
-//
-//	}
-// @formatter:on
 
 	public List<QFAttribute> getAttributes() throws QueryFilterDefinitionException {
 
@@ -151,7 +64,7 @@ class FieldClassProcessor {
 						pathField);
 				throw new QFElementException(pathField, subclassMapping);
 			}
-			if (subClassMappingPath.isEmpty()) {
+			if (subClassMappingPath == null || subClassMappingPath.isEmpty()) {
 				levelsSubClass = new String[0];
 			} else {
 				levelsSubClass = subClassMappingPath.split("\\.");
@@ -166,7 +79,7 @@ class FieldClassProcessor {
 			LOGGER.trace("Processing level {}", level);
 			actualLevel++;
 
-			Class<?> treatClass = null;
+			Class<?> treatClass;
 
 			if (levelsSubClass != null && levelsSubClass.length == actualLevel) {
 				// Check levelClass is parent of subclassMapping
@@ -196,15 +109,6 @@ class FieldClassProcessor {
 
 		}
 
-		// if (checkFinal) {
-		// Class<?> finalClass = attributes.get(attributes.size() -
-		// 1).getAttribute().getJavaType();
-		// if (!couldBeFinal(finalClass)) {
-		// throw new QFFieldLevelException(pathField, splitLevel[splitLevel.length -
-		// 1]);
-		// }
-		// }
-
 		finalClass = attributes.get(attributes.size() - 1).getAttribute().getJavaType();
 
 		return attributes;
@@ -222,7 +126,6 @@ class FieldClassProcessor {
 			return processType(singularAttribute.getType(), level);
 		}
 
-		// TODO
 		throw new IllegalArgumentException("Attribute type not supported");
 
 	}
@@ -243,39 +146,4 @@ class FieldClassProcessor {
 		return finalClass;
 	}
 
-// @formatter:off
-//	private static QFPath createQPathOfField(Field field, String path, Class<?> treatClass)
-//			throws QueryFilterDefinitionException {
-//
-//		LOGGER.trace("Processing field {}", field);
-//
-//		Class<?> fieldClass = field.getType();
-//
-//		Class<?> finalClass = fieldClass;
-//		boolean isFinal = false;
-//		QFElementDefType type;
-//
-//		if (Enum.class.isAssignableFrom(fieldClass) || fieldClass.isEnum()) {
-//			type = QFElementDefType.ENUM;
-//			isFinal = true;
-//		} else if (ClassUtils.isPrimitiveOrBasic(fieldClass)) {
-//			isFinal = true;
-//			type = QFElementDefType.PROPERTY;
-//		} else if (fieldClass.isArray()) {
-//			finalClass = fieldClass.getComponentType();
-//			type = QFElementDefType.LIST;
-//		} else if (List.class.isAssignableFrom(fieldClass) || Set.class.isAssignableFrom(fieldClass)) {
-//			finalClass = ClassUtils.getClassOfList(field);
-//			type = List.class.isAssignableFrom(fieldClass) ? QFElementDefType.LIST : QFElementDefType.SET;
-//		} else {
-//			type = QFElementDefType.PROPERTY;
-//		}
-//
-//		return new QFPath(field, path, type, finalClass, isFinal, treatClass);
-//	}
-// @formatter:on
-
-	private static boolean couldBeFinal(Class<?> clazz) {
-		return Enum.class.isAssignableFrom(clazz) || clazz.isEnum() || ClassUtils.isPrimitiveOrBasic(clazz);
-	}
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
@@ -3,6 +3,7 @@ package io.github.acoboh.query.filter.jpa.processor.definitions;
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,6 +12,7 @@ import io.github.acoboh.query.filter.jpa.annotations.QFBlockParsing;
 import io.github.acoboh.query.filter.jpa.annotations.QFCollectionElement;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QFCollectionNotSupported;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
+import io.github.acoboh.query.filter.jpa.operations.QFCollectionOperationEnum;
 import io.github.acoboh.query.filter.jpa.processor.QFAttribute;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.metamodel.Metamodel;
@@ -24,6 +26,7 @@ public class QFDefinitionCollection extends QFAbstractDefinition {
 
 	private final List<QFAttribute> attributes;
 	private final List<JoinType> joinTypes;
+	private final Set<QFCollectionOperationEnum> allowedOperations;
 
 	QFDefinitionCollection(Field filterField, Class<?> filterClass, Class<?> entityClass, QFBlockParsing blockParsing,
 			QFCollectionElement collectionElement, Metamodel metamodel) throws QueryFilterDefinitionException {
@@ -49,6 +52,7 @@ public class QFDefinitionCollection extends QFAbstractDefinition {
 			this.joinTypes = List.of(collectionElement.joinTypes());
 		}
 
+		allowedOperations = Set.of(collectionElement.allowedOperations());
 	}
 
 	/**
@@ -67,6 +71,17 @@ public class QFDefinitionCollection extends QFAbstractDefinition {
 	 */
 	public List<JoinType> getJoinTypes() {
 		return joinTypes;
+	}
+
+	public boolean isOperationAllowed(QFCollectionOperationEnum operation) {
+		return allowedOperations.isEmpty() || allowedOperations.contains(operation);
+	}
+
+	public Set<QFCollectionOperationEnum> getRealAllowedOperations() {
+		if (allowedOperations.isEmpty()) {
+			return Set.of(QFCollectionOperationEnum.values());
+		}
+		return allowedOperations;
 	}
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionCollection.java
@@ -32,7 +32,7 @@ public class QFDefinitionCollection extends QFAbstractDefinition {
 			QFCollectionElement collectionElement, Metamodel metamodel) throws QueryFilterDefinitionException {
 		super(filterField, filterClass, entityClass, blockParsing);
 
-		var fieldClassProcessor = new FieldClassProcessor(entityClass, collectionElement.value(), false,
+		var fieldClassProcessor = new FieldClassProcessor(entityClass, collectionElement.value(),
 				collectionElement.subClassMapping(), collectionElement.subClassMappingPath(), metamodel);
 
 		this.attributes = fieldClassProcessor.getAttributes();

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,6 +14,7 @@ import io.github.acoboh.query.filter.jpa.annotations.QFBlockParsing;
 import io.github.acoboh.query.filter.jpa.annotations.QFDiscriminator;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QFDiscriminatorException;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
+import io.github.acoboh.query.filter.jpa.operations.QFOperationDiscriminatorEnum;
 import io.github.acoboh.query.filter.jpa.processor.QFAttribute;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.metamodel.Metamodel;
@@ -28,6 +30,7 @@ public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 	private final List<QFAttribute> attributes;
 	private final List<JoinType> joinTypes;
 	private final Class<?> finalClass;
+	private final Set<QFOperationDiscriminatorEnum> allowedOperations;
 
 	private final Map<String, Class<?>> discriminatorMap = new HashMap<>();
 
@@ -66,11 +69,13 @@ public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 		}
 
 		if (discriminatorAnnotation.joinTypes().length == 0) {
-			LOGGER.warn("No join types defined for discriminator {}. Defaulting to INNER", filterName);
+			LOGGER.debug("No join types defined for discriminator {}. Defaulting to INNER", filterName);
 			this.joinTypes = List.of(JoinType.INNER);
 		} else {
 			this.joinTypes = List.of(discriminatorAnnotation.joinTypes());
 		}
+
+		allowedOperations = Set.of(discriminatorAnnotation.allowedOperations());
 
 	}
 
@@ -117,6 +122,17 @@ public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 	 */
 	public List<JoinType> getJoinTypes() {
 		return joinTypes;
+	}
+
+	public boolean isOperationAllowed(QFOperationDiscriminatorEnum operation) {
+		return allowedOperations.isEmpty() || allowedOperations.contains(operation);
+	}
+
+	public Set<QFOperationDiscriminatorEnum> getRealAllowedOperations() {
+		if (allowedOperations.isEmpty()) {
+			return Set.of(QFOperationDiscriminatorEnum.values());
+		}
+		return allowedOperations;
 	}
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionDiscriminator.java
@@ -42,8 +42,8 @@ public class QFDefinitionDiscriminator extends QFAbstractDefinition {
 		this.discriminatorAnnotation = discriminatorAnnotation;
 
 		if (!discriminatorAnnotation.path().isEmpty()) {
-			var fieldClassProcessor = new FieldClassProcessor(entityClass, discriminatorAnnotation.path(), false, null,
-					null, metamodel);
+			var fieldClassProcessor = new FieldClassProcessor(entityClass, discriminatorAnnotation.path(), null, null,
+					metamodel);
 			this.attributes = fieldClassProcessor.getAttributes();
 			this.finalClass = fieldClassProcessor.getFinalClass();
 		} else {

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionElement.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionElement.java
@@ -164,7 +164,7 @@ public final class QFDefinitionElement extends QFAbstractDefinition implements I
 
 		for (QFElement elem : elementAnnotations) {
 			LOGGER.trace("Creating paths for element annotation {}", elem);
-			var fieldClassProcessor = new FieldClassProcessor(entityClass, elem.value(), true, elem.subClassMapping(),
+			var fieldClassProcessor = new FieldClassProcessor(entityClass, elem.value(), elem.subClassMapping(),
 					elem.subClassMappingPath(), metamodel);
 
 			List<QFAttribute> attributes = fieldClassProcessor.getAttributes();

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
@@ -2,6 +2,7 @@ package io.github.acoboh.query.filter.jpa.processor.definitions;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,6 +11,7 @@ import io.github.acoboh.query.filter.jpa.annotations.QFBlockParsing;
 import io.github.acoboh.query.filter.jpa.annotations.QFJsonElement;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QFJsonException;
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
+import io.github.acoboh.query.filter.jpa.operations.QFOperationJsonEnum;
 import io.github.acoboh.query.filter.jpa.processor.QFAttribute;
 import jakarta.persistence.Column;
 import jakarta.persistence.criteria.JoinType;
@@ -25,6 +27,7 @@ public class QFDefinitionJson extends QFAbstractDefinition {
 	private final QFJsonElement jsonAnnotation;
 	private final List<QFAttribute> attributes;
 	private final List<JoinType> joinTypes;
+	private final Set<QFOperationJsonEnum> allowedOperations;
 
 	QFDefinitionJson(Field filterField, Class<?> filterClass, Class<?> entityClass, QFBlockParsing blockParsing,
 			QFJsonElement jsonAnnotation, Metamodel metamodel) throws QueryFilterDefinitionException {
@@ -54,6 +57,8 @@ public class QFDefinitionJson extends QFAbstractDefinition {
 		} else {
 			this.joinTypes = List.of(jsonAnnotation.joinTypes());
 		}
+
+		allowedOperations = Set.of(jsonAnnotation.allowedOperations());
 
 	}
 
@@ -98,6 +103,17 @@ public class QFDefinitionJson extends QFAbstractDefinition {
 	 */
 	public List<JoinType> getJoinTypes() {
 		return joinTypes;
+	}
+
+	public boolean isOperationAllowed(QFOperationJsonEnum operation) {
+		return allowedOperations.isEmpty() || allowedOperations.contains(operation);
+	}
+
+	public Set<QFOperationJsonEnum> getRealAllowedOperations() {
+		if (allowedOperations.isEmpty()) {
+			return Set.of(QFOperationJsonEnum.values());
+		}
+		return allowedOperations;
 	}
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionJson.java
@@ -39,8 +39,7 @@ public class QFDefinitionJson extends QFAbstractDefinition {
 			super.filterName = jsonAnnotation.name();
 		}
 
-		var fieldClassProcessor = new FieldClassProcessor(entityClass, jsonAnnotation.value(), false, null, null,
-				metamodel);
+		var fieldClassProcessor = new FieldClassProcessor(entityClass, jsonAnnotation.value(), null, null, metamodel);
 
 		this.attributes = fieldClassProcessor.getAttributes();
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/definitions/QFDefinitionSortable.java
@@ -36,8 +36,8 @@ public class QFDefinitionSortable extends QFAbstractDefinition implements IDefin
 
 		attributes = new ArrayList<>(1); // Only one path
 
-		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, sortableAnnotation.value(), true,
-				null, null, metamodel);
+		FieldClassProcessor fieldClassProcessor = new FieldClassProcessor(entityClass, sortableAnnotation.value(), null,
+				null, metamodel);
 		attributes.add(fieldClassProcessor.getAttributes());
 
 		autoFetch = sortableAnnotation.autoFetch();

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFCollectionMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFCollectionMatch.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.springframework.util.MultiValueMap;
 
 import io.github.acoboh.query.filter.jpa.exceptions.QFCollectionException;
+import io.github.acoboh.query.filter.jpa.exceptions.QFOperationNotAllowed;
 import io.github.acoboh.query.filter.jpa.operations.QFCollectionOperationEnum;
 import io.github.acoboh.query.filter.jpa.processor.QFSpecificationPart;
 import io.github.acoboh.query.filter.jpa.processor.QueryUtils;
@@ -41,7 +42,11 @@ public class QFCollectionMatch implements QFSpecificationPart {
 	 *            value of the element operation
 	 */
 	public QFCollectionMatch(QFDefinitionCollection definition, QFCollectionOperationEnum operation, int value) {
-		super();
+
+		if (!definition.isOperationAllowed(operation)) {
+			throw new QFOperationNotAllowed(definition.getFilterName(), operation.getOperation());
+		}
+
 		this.definition = definition;
 		this.operation = operation;
 		this.value = value;
@@ -79,10 +84,11 @@ public class QFCollectionMatch implements QFSpecificationPart {
 	@Override
 	public <E> void processPart(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder,
 			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
-			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass) {
+			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass,
+			boolean isCount) {
 
 		Path<?> expressionPath = QueryUtils.getObject(root, definition.getPaths(), definition.getJoinTypes(), pathsMap,
-				true, false, criteriaBuilder);
+				true, false, isCount, criteriaBuilder);
 
 		Expression<? extends java.util.Collection<?>> expression;
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFCollectionMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFCollectionMatch.java
@@ -10,15 +10,13 @@ import io.github.acoboh.query.filter.jpa.exceptions.QFCollectionException;
 import io.github.acoboh.query.filter.jpa.exceptions.QFOperationNotAllowed;
 import io.github.acoboh.query.filter.jpa.operations.QFCollectionOperationEnum;
 import io.github.acoboh.query.filter.jpa.processor.QFSpecificationPart;
+import io.github.acoboh.query.filter.jpa.processor.QueryInfo;
 import io.github.acoboh.query.filter.jpa.processor.QueryUtils;
 import io.github.acoboh.query.filter.jpa.processor.definitions.QFDefinitionCollection;
 import io.github.acoboh.query.filter.jpa.spel.SpelResolverContext;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
 
 /**
  * @author Adrián Cobo
@@ -82,13 +80,12 @@ public class QFCollectionMatch implements QFSpecificationPart {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <E> void processPart(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder,
-			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
-			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass,
-			boolean isCount) {
+	public <E> void processPart(QueryInfo<E> queryInfo, Map<String, List<Predicate>> predicatesMap,
+			Map<String, Path<?>> pathsMap, MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver,
+			Class<E> entityClass) {
 
-		Path<?> expressionPath = QueryUtils.getObject(root, definition.getPaths(), definition.getJoinTypes(), pathsMap,
-				true, false, isCount, criteriaBuilder);
+		Path<?> expressionPath = QueryUtils.getObject(queryInfo, definition.getPaths(), definition.getJoinTypes(),
+				pathsMap, true, false);
 
 		Expression<? extends java.util.Collection<?>> expression;
 
@@ -99,7 +96,7 @@ public class QFCollectionMatch implements QFSpecificationPart {
 		}
 
 		predicatesMap.computeIfAbsent(definition.getFilterName(), t -> new ArrayList<>())
-				.add(operation.generateCollectionPredicate(expression, criteriaBuilder, this, mlmap));
+				.add(operation.generateCollectionPredicate(expression, queryInfo.cb(), this, mlmap));
 
 	}
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFDiscriminatorMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFDiscriminatorMatch.java
@@ -13,15 +13,13 @@ import io.github.acoboh.query.filter.jpa.exceptions.QFOperationNotAllowed;
 import io.github.acoboh.query.filter.jpa.operations.QFOperationDiscriminatorEnum;
 import io.github.acoboh.query.filter.jpa.processor.QFAttribute;
 import io.github.acoboh.query.filter.jpa.processor.QFSpecificationPart;
+import io.github.acoboh.query.filter.jpa.processor.QueryInfo;
 import io.github.acoboh.query.filter.jpa.processor.QueryUtils;
 import io.github.acoboh.query.filter.jpa.processor.definitions.QFDefinitionDiscriminator;
 import io.github.acoboh.query.filter.jpa.spel.SpelResolverContext;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
 
 /**
  * Class with info about the discriminator matching for filtering
@@ -150,22 +148,20 @@ public class QFDiscriminatorMatch implements QFSpecificationPart {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <E> void processPart(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder,
-			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
-			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass,
-			boolean isCount) {
+	public <E> void processPart(QueryInfo<E> queryInfo, Map<String, List<Predicate>> predicatesMap,
+			Map<String, Path<?>> pathsMap, MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver,
+			Class<E> entityClass) {
 
 		Expression<?> expression;
 		if (isRoot) {
-			expression = root.type();
+			expression = queryInfo.root().type();
 		} else {
-			expression = QueryUtils
-					.getObject(root, path, definition.getJoinTypes(), pathsMap, false, false, isCount, criteriaBuilder)
+			expression = QueryUtils.getObject(queryInfo, path, definition.getJoinTypes(), pathsMap, false, false)
 					.type();
 		}
 
 		predicatesMap.computeIfAbsent(definition.getFilterName(), t -> new ArrayList<>()).add(operation
-				.generateDiscriminatorPredicate((Expression<Class<?>>) expression, criteriaBuilder, this, mlmap));
+				.generateDiscriminatorPredicate((Expression<Class<?>>) expression, queryInfo.cb(), this, mlmap));
 
 	}
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFElementMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFElementMatch.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 import org.springframework.util.MultiValueMap;
 
 import io.github.acoboh.query.filter.jpa.exceptions.QFDateParsingException;
@@ -22,12 +23,11 @@ import io.github.acoboh.query.filter.jpa.exceptions.QFOperationNotAllowed;
 import io.github.acoboh.query.filter.jpa.operations.QFOperationEnum;
 import io.github.acoboh.query.filter.jpa.processor.QFAttribute;
 import io.github.acoboh.query.filter.jpa.processor.QFSpecificationPart;
+import io.github.acoboh.query.filter.jpa.processor.QueryInfo;
 import io.github.acoboh.query.filter.jpa.processor.QueryUtils;
 import io.github.acoboh.query.filter.jpa.processor.definitions.QFDefinitionElement;
 import io.github.acoboh.query.filter.jpa.spel.SpelResolverContext;
 import io.github.acoboh.query.filter.jpa.utils.DateUtils;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
@@ -377,6 +377,17 @@ public class QFElementMatch implements QFSpecificationPart {
 		}
 
 		// Primitive array copy
+		List<String> retList = getStringFromArrays(spelResolved, originalClass);
+
+		if (retList != null) {
+			return retList;
+		}
+
+		return Collections.singletonList(spelResolved.toString());
+	}
+
+	@Nullable
+	private List<String> getStringFromArrays(Object spelResolved, Class<?> originalClass) {
 		List<String> retList = null;
 		if (boolean[].class.equals(originalClass)) {
 			boolean[] fromArray = (boolean[]) spelResolved;
@@ -434,34 +445,26 @@ public class QFElementMatch implements QFSpecificationPart {
 				retList.add(String.valueOf(c));
 			}
 		}
-
-		if (retList != null) {
-			return retList;
-		}
-
-		return Collections.singletonList(spelResolved.toString());
+		return retList;
 	}
 
 	@Override
-	public <E> void processPart(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder,
-			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
-			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass,
-			boolean isCount) {
+	public <E> void processPart(QueryInfo<E> queryInfo, Map<String, List<Predicate>> predicatesMap,
+			Map<String, Path<?>> pathsMap, MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver,
+			Class<E> entityClass) {
 
 		if (definition.isSubQuery()) {
 			LOGGER.trace("Element match is subquery");
-			processPartAsSubQuery(root, query, criteriaBuilder, predicatesMap, mlmap, spelResolver, entityClass,
-					isCount);
+			processPartAsSubQuery(queryInfo, predicatesMap, mlmap, spelResolver, entityClass);
 		} else {
 			LOGGER.trace("Element match is basic");
-			processAsElement(root, criteriaBuilder, predicatesMap, pathsMap, mlmap, spelResolver, isCount);
+			processAsElement(queryInfo, predicatesMap, pathsMap, mlmap, spelResolver);
 		}
 
 	}
 
-	private <E> void processAsElement(Root<E> root, CriteriaBuilder criteriaBuilder,
-			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
-			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, boolean isCount) {
+	private <E> void processAsElement(QueryInfo<E> queryInfo, Map<String, List<Predicate>> predicatesMap,
+			Map<String, Path<?>> pathsMap, MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver) {
 		initialize(spelResolver, mlmap);
 
 		if (!needToEvaluate()) {
@@ -473,19 +476,19 @@ public class QFElementMatch implements QFSpecificationPart {
 		List<Predicate> predicates = new ArrayList<>();
 
 		for (var path : paths) {
-			predicates.add(operation.generatePredicate(QueryUtils.getObject(root, path, definition.getJoinTypes(index),
-					pathsMap, false, false, isCount, criteriaBuilder), criteriaBuilder, this, index, mlmap));
+			predicates.add(operation.generatePredicate(
+					QueryUtils.getObject(queryInfo, path, definition.getJoinTypes(index), pathsMap, false, false),
+					queryInfo.cb(), this, index, mlmap));
 			index++;
 		}
 
-		Predicate surrondingPredicate = definition.getPredicateOperation().getPredicate(criteriaBuilder, predicates);
+		Predicate surrondingPredicate = definition.getPredicateOperation().getPredicate(queryInfo.cb(), predicates);
 
 		predicatesMap.computeIfAbsent(definition.getFilterName(), t -> new ArrayList<>()).add(surrondingPredicate);
 	}
 
-	private <E> void processPartAsSubQuery(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder,
-			Map<String, List<Predicate>> predicatesMap, MultiValueMap<String, Object> mlmap,
-			SpelResolverContext spelResolver, Class<E> entityClass, boolean isCount) {
+	private <E> void processPartAsSubQuery(QueryInfo<E> queryInfo, Map<String, List<Predicate>> predicatesMap,
+			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass) {
 		Map<String, Path<?>> subSelecthMap = new HashMap<>();
 
 		initialize(spelResolver, mlmap);
@@ -497,25 +500,27 @@ public class QFElementMatch implements QFSpecificationPart {
 		int index = 0;
 		for (var path : paths) {
 
-			Subquery<E> subquery = query.subquery(entityClass);
+			Subquery<E> subquery = queryInfo.query().subquery(entityClass);
 			Root<E> newRoot = subquery.from(entityClass);
 
 			subquery.select(newRoot);
 
-			Path<?> pathFinal = QueryUtils.getObject(newRoot, path, definition.getJoinTypes(index), subSelecthMap,
-					false, false, isCount, criteriaBuilder);
+			QueryInfo<E> subQueryInfo = new QueryInfo<>(newRoot, null, queryInfo.cb(), false);
+
+			Path<?> pathFinal = QueryUtils.getObject(subQueryInfo, path, definition.getJoinTypes(index), subSelecthMap,
+					false, false);
 
 			QFOperationEnum op = operation;
 			if (op == QFOperationEnum.NOT_EQUAL) {
 				op = QFOperationEnum.EQUAL;
 			}
 
-			subquery.where(op.generatePredicate(pathFinal, criteriaBuilder, this, index, mlmap));
+			subquery.where(op.generatePredicate(pathFinal, queryInfo.cb(), this, index, mlmap));
 
-			Predicate finalPredicate = criteriaBuilder.in(root).value(subquery);
+			Predicate finalPredicate = queryInfo.cb().in(queryInfo.root()).value(subquery);
 
 			if (operation == QFOperationEnum.NOT_EQUAL) {
-				finalPredicate = criteriaBuilder.not(finalPredicate);
+				finalPredicate = queryInfo.cb().not(finalPredicate);
 			}
 
 			predicatesMap.computeIfAbsent(definition.getFilterName(), k -> new ArrayList<>()).add(finalPredicate);

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFJsonElementMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFJsonElementMatch.java
@@ -22,14 +22,12 @@ import io.github.acoboh.query.filter.jpa.exceptions.QFJsonParseException;
 import io.github.acoboh.query.filter.jpa.exceptions.QFOperationNotAllowed;
 import io.github.acoboh.query.filter.jpa.operations.QFOperationJsonEnum;
 import io.github.acoboh.query.filter.jpa.processor.QFSpecificationPart;
+import io.github.acoboh.query.filter.jpa.processor.QueryInfo;
 import io.github.acoboh.query.filter.jpa.processor.QueryUtils;
 import io.github.acoboh.query.filter.jpa.processor.definitions.QFDefinitionJson;
 import io.github.acoboh.query.filter.jpa.spel.SpelResolverContext;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
 
 /**
  * Class with JSON element matching definition
@@ -170,15 +168,13 @@ public class QFJsonElementMatch implements QFSpecificationPart {
 	}
 
 	@Override
-	public <E> void processPart(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder,
-			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
-			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass,
-			boolean isCount) {
+	public <E> void processPart(QueryInfo<E> queryInfo, Map<String, List<Predicate>> predicatesMap,
+			Map<String, Path<?>> pathsMap, MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver,
+			Class<E> entityClass) {
 
 		predicatesMap.computeIfAbsent(definition.getFilterName(), t -> new ArrayList<>())
-				.add(operation.generateJsonPredicate(QueryUtils.getObject(root, definition.getAttributes(),
-						definition.getJoinTypes(), pathsMap, true, false, isCount, criteriaBuilder), criteriaBuilder,
-						this));
+				.add(operation.generateJsonPredicate(QueryUtils.getObject(queryInfo, definition.getAttributes(),
+						definition.getJoinTypes(), pathsMap, true, false), queryInfo.cb(), this));
 
 	}
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFJsonElementMatch.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/processor/match/QFJsonElementMatch.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 
 import io.github.acoboh.query.filter.jpa.exceptions.QFJsonParseException;
+import io.github.acoboh.query.filter.jpa.exceptions.QFOperationNotAllowed;
 import io.github.acoboh.query.filter.jpa.operations.QFOperationJsonEnum;
 import io.github.acoboh.query.filter.jpa.processor.QFSpecificationPart;
 import io.github.acoboh.query.filter.jpa.processor.QueryUtils;
@@ -65,6 +66,10 @@ public class QFJsonElementMatch implements QFSpecificationPart {
 	 */
 	public QFJsonElementMatch(String value, QFOperationJsonEnum operation, QFDefinitionJson definition)
 			throws QFJsonParseException {
+
+		if (!definition.isOperationAllowed(operation)) {
+			throw new QFOperationNotAllowed(definition.getFilterName(), operation.getOperation());
+		}
 
 		this.definition = definition;
 		this.operation = operation;
@@ -167,11 +172,13 @@ public class QFJsonElementMatch implements QFSpecificationPart {
 	@Override
 	public <E> void processPart(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder,
 			Map<String, List<Predicate>> predicatesMap, Map<String, Path<?>> pathsMap,
-			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass) {
+			MultiValueMap<String, Object> mlmap, SpelResolverContext spelResolver, Class<E> entityClass,
+			boolean isCount) {
 
 		predicatesMap.computeIfAbsent(definition.getFilterName(), t -> new ArrayList<>())
 				.add(operation.generateJsonPredicate(QueryUtils.getObject(root, definition.getAttributes(),
-						definition.getJoinTypes(), pathsMap, true, false, criteriaBuilder), criteriaBuilder, this));
+						definition.getJoinTypes(), pathsMap, true, false, isCount, criteriaBuilder), criteriaBuilder,
+						this));
 
 	}
 

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/properties/AdvisorProperties.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/properties/AdvisorProperties.java
@@ -22,6 +22,8 @@ public class AdvisorProperties {
 
 	private boolean messageSourceUseCodeAsDefaultMessage = true;
 
+	private boolean extendErrorMessage = false;
+
 	/**
 	 * Get if the advisor is enabled
 	 *
@@ -96,6 +98,25 @@ public class AdvisorProperties {
 	 */
 	public void setMessageSourceUseCodeAsDefaultMessage(boolean messageSourceUseCodeAsDefaultMessage) {
 		this.messageSourceUseCodeAsDefaultMessage = messageSourceUseCodeAsDefaultMessage;
+	}
+
+	/**
+	 * Get if the error message should be extended
+	 *
+	 * @return if the error message should be extended
+	 */
+	public boolean isExtendErrorMessage() {
+		return extendErrorMessage;
+	}
+
+	/**
+	 * Set if the error message should be extended
+	 *
+	 * @param extendErrorMessage
+	 *            if the error message should be extended
+	 */
+	public void setExtendErrorMessage(boolean extendErrorMessage) {
+		this.extendErrorMessage = extendErrorMessage;
 	}
 
 }

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/properties/QueryFilterProperties.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/properties/QueryFilterProperties.java
@@ -35,4 +35,6 @@ public class QueryFilterProperties {
 		this.advisor = advisor;
 	}
 
+
+
 }

--- a/query-filter-jpa-3/src/main/resources/queryfilter-messages/messages_en.properties
+++ b/query-filter-jpa-3/src/main/resources/queryfilter-messages/messages_en.properties
@@ -1,13 +1,13 @@
-
-qf.exceptions.blocked                  = The field ''{0}'' is blocked from parsing. Operation not allowed
-qf.exceptions.dateParse                = The date format ''{0}'' is not valid for field ''{1}''. Allowed format ''{2}''
-qf.exceptions.discriminatorTypeMissing = The type ''{0}'' is not a valid discriminator for field ''{1}''
-qf.exceptions.enum                     = Failed to parse field ''{0}'' with value ''{1}'' to enum class ''{2}''. Allowed values {3}
-qf.exceptions.json                     = Error parsing field ''{0}'' JSON type. Error: ''{1}''
-qf.exceptions.missingField             = The field ''{0}'' can not be found. Please check the input filter
-qf.exceptions.multipleSort             = Multiple sorting operations on the same field ''{0}''
-qf.exceptions.notSortable              = The field ''{0}'' is not sortable
-qf.exceptions.notValuable              = The field ''{0}'' does not allowed any operation
-qf.exceptions.operationFieldNotValid   = The operation ''{0}'' is not valid for field ''{1}''. Please check the documentation
-qf.exceptions.operationNotFound        = Operation ''{0}'' not found
-qf.exceptions.parse                    = Can not be parsed succesfully the field ''{0}''. Please check the filter input: ''{1}''
+qf.exceptions.blocked=The field ''{0}'' is blocked from parsing. Operation not allowed
+qf.exceptions.dateParse=The date format ''{0}'' is not valid for field ''{1}''. Allowed format ''{2}''
+qf.exceptions.discriminatorTypeMissing=The type ''{0}'' is not a valid discriminator for field ''{1}''
+qf.exceptions.enum=Failed to parse field ''{0}'' with value ''{1}'' to enum class ''{2}''. Allowed values {3}
+qf.exceptions.json=Error parsing field ''{0}'' JSON type. Error: ''{1}''
+qf.exceptions.missingField=The field ''{0}'' can not be found. Please check the input filter
+qf.exceptions.multipleSort=Multiple sorting operations on the same field ''{0}''
+qf.exceptions.notSortable=The field ''{0}'' is not sortable
+qf.exceptions.notValuable=The field ''{0}'' does not allowed any operation
+qf.exceptions.operation-not-allowed=The operation ''{0}'' is not allowed on field ''{1}''
+qf.exceptions.operationFieldNotValid=The operation ''{0}'' is not valid for field ''{1}''. Please check the documentation
+qf.exceptions.operationNotFound=Operation ''{0}'' not found
+qf.exceptions.parse=Can not be parsed succesfully the field ''{0}''. Please check the filter input: ''{1}''

--- a/query-filter-jpa-3/src/main/resources/queryfilter-messages/messages_es.properties
+++ b/query-filter-jpa-3/src/main/resources/queryfilter-messages/messages_es.properties
@@ -1,13 +1,13 @@
-
-qf.exceptions.blocked                  = El campo ''{0}'' est\u00E1 bloqueado. La operaci\u00F3n no est\u00E1 permitida
-qf.exceptions.dateParse                = El formato de fecha ''{0}'' no es v\u00E1lido para el campo ''{1}''. Formato permitido ''{2}''
-qf.exceptions.discriminatorTypeMissing = El tipo ''{0}'' no es un discriminador v\u00E1lido para el campo ''{1}''
-qf.exceptions.enum                     = Fallo al crear un enumerado del campo ''{0}'' para el valor ''{1}'' para el enumerado ''{2}''. Valores permitidos: {3}
-qf.exceptions.json                     = Error al parsear el campo ''{0}'' de tipo JSON. Error: ''{1}''
-qf.exceptions.missingField             = No se ha podido encontrar el campo ''{0}''. Revisa el filtro de entrada
-qf.exceptions.multipleSort             = Hay m\u00FAltiples operaciones de ordenado para el mismo campo ''{0}''
-qf.exceptions.notSortable              = El campo ''{0}'' no es ordenable
-qf.exceptions.notValuable              = El campo ''{0}'' no permite ninguna operacion
-qf.exceptions.operationFieldNotValid   = La operation ''{0}'' no est\u00E1 soportada para el campo ''{1}''. Revisa la documentaci\u00F3n
-qf.exceptions.operationNotFound        = No se ha encontrado la operacion ''{0}''
-qf.exceptions.parse                    = No se puede parsear correctamente el campo ''{0}''. Por favor, revisa el filtro: ''{1}''
+qf.exceptions.blocked=El campo ''{0}'' est\u00E1 bloqueado. La operaci\u00F3n no est\u00E1 permitida
+qf.exceptions.dateParse=El formato de fecha ''{0}'' no es v\u00E1lido para el campo ''{1}''. Formato permitido ''{2}''
+qf.exceptions.discriminatorTypeMissing=El tipo ''{0}'' no es un discriminador v\u00E1lido para el campo ''{1}''
+qf.exceptions.enum=Fallo al crear un enumerado del campo ''{0}'' para el valor ''{1}'' para el enumerado ''{2}''. Valores permitidos: {3}
+qf.exceptions.json=Error al parsear el campo ''{0}'' de tipo JSON. Error: ''{1}''
+qf.exceptions.missingField=No se ha podido encontrar el campo ''{0}''. Revisa el filtro de entrada
+qf.exceptions.multipleSort=Hay m\u00FAltiples operaciones de ordenado para el mismo campo ''{0}''
+qf.exceptions.notSortable=El campo ''{0}'' no es ordenable
+qf.exceptions.notValuable=El campo ''{0}'' no permite ninguna operacion
+qf.exceptions.operation-not-allowed=La operación ''{0}'' no está permitida en el campo ''{1}''
+qf.exceptions.operationFieldNotValid=La operation ''{0}'' no est\u00E1 soportada para el campo ''{1}''. Revisa la documentaci\u00F3n
+qf.exceptions.operationNotFound=No se ha encontrado la operacion ''{0}''
+qf.exceptions.parse=No se puede parsear correctamente el campo ''{0}''. Por favor, revisa el filtro: ''{1}''

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterAllowedOperationsBlogDef.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterAllowedOperationsBlogDef.java
@@ -1,0 +1,15 @@
+package io.github.acoboh.query.filter.jpa.domain;
+
+import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
+import io.github.acoboh.query.filter.jpa.annotations.QFElement;
+import io.github.acoboh.query.filter.jpa.model.PostBlog;
+import io.github.acoboh.query.filter.jpa.operations.QFOperationEnum;
+
+@QFDefinitionClass(PostBlog.class)
+public class FilterAllowedOperationsBlogDef {
+
+	@QFElement(value = "author", allowedOperations = {QFOperationEnum.EQUAL, QFOperationEnum.STARTS_WITH,
+			QFOperationEnum.ENDS_WITH, QFOperationEnum.LIKE})
+	private String author;
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterCommentBlogDef.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/domain/FilterCommentBlogDef.java
@@ -1,0 +1,17 @@
+package io.github.acoboh.query.filter.jpa.domain;
+
+import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
+import io.github.acoboh.query.filter.jpa.annotations.QFElement;
+import io.github.acoboh.query.filter.jpa.annotations.QFSortable;
+import io.github.acoboh.query.filter.jpa.model.Comments;
+
+@QFDefinitionClass(Comments.class)
+public class FilterCommentBlogDef {
+
+	@QFSortable("postBlog.author")
+	private String blogAuthor;
+
+	@QFElement("postBlog.author")
+	private String blogAuthorElem;
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/filtererrors/discriminator/OperationAllowedError1Def.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/filtererrors/discriminator/OperationAllowedError1Def.java
@@ -1,0 +1,14 @@
+package io.github.acoboh.query.filter.jpa.filtererrors.discriminator;
+
+import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
+import io.github.acoboh.query.filter.jpa.annotations.QFElement;
+import io.github.acoboh.query.filter.jpa.model.PostBlog;
+import io.github.acoboh.query.filter.jpa.operations.QFOperationEnum;
+
+@QFDefinitionClass(PostBlog.class)
+public class OperationAllowedError1Def {
+
+	@QFElement(value = "likes", allowedOperations = QFOperationEnum.ENDS_WITH)
+	private int likes;
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/model/PostBlog.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/model/PostBlog.java
@@ -96,9 +96,10 @@ public class PostBlog {
 		PostBlog other = (PostBlog) obj;
 		return Objects.equals(author, other.author)
 				&& Double.doubleToLongBits(avgNote) == Double.doubleToLongBits(other.avgNote)
-				&& createDate.equals(other.createDate) && lastTimestamp.equals(other.lastTimestamp)
-				&& Objects.equals(instant, other.instant) && likes == other.likes && postType == other.postType
-				&& published == other.published && Objects.equals(text, other.text) && Objects.equals(uuid, other.uuid)
+				&& Objects.equals(this.createDate, other.createDate)
+				&& Objects.equals(lastTimestamp, other.getLastTimestamp()) && Objects.equals(instant, other.instant)
+				&& likes == other.likes && postType == other.postType && published == other.published
+				&& Objects.equals(text, other.text) && Objects.equals(uuid, other.uuid)
 				&& Arrays.equals(tags, other.tags);
 	}
 

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/AutoFetchSortBugTest.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/AutoFetchSortBugTest.java
@@ -30,7 +30,7 @@ import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class AutoFetchSortBugTest {
+class AutoFetchSortBugTest {
 
 	private static final PostBlog POST_BLOG = new PostBlog();
 	private static final Comments COMMENT = new Comments();

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/AutoFetchSortBugTest.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/AutoFetchSortBugTest.java
@@ -1,0 +1,132 @@
+package io.github.acoboh.query.filter.jpa.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.util.Pair;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import io.github.acoboh.query.filter.jpa.domain.FilterCommentBlogDef;
+import io.github.acoboh.query.filter.jpa.model.Comments;
+import io.github.acoboh.query.filter.jpa.model.PostBlog;
+import io.github.acoboh.query.filter.jpa.repositories.CommentsRepository;
+import io.github.acoboh.query.filter.jpa.repositories.PostBlogRepository;
+import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
+
+@SpringJUnitWebConfig(SpringIntegrationTestBase.Config.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class AutoFetchSortBugTest {
+
+	private static final PostBlog POST_BLOG = new PostBlog();
+	private static final Comments COMMENT = new Comments();
+	private static final Comments COMMENT2 = new Comments();
+	private static final Comments COMMENT3 = new Comments();
+
+	static {
+		POST_BLOG.setUuid(UUID.randomUUID());
+		POST_BLOG.setAuthor("Author");
+		POST_BLOG.setText("Text");
+		POST_BLOG.setAvgNote(2.5d);
+		POST_BLOG.setLikes(100);
+
+		COMMENT.setId(1);
+		COMMENT.setAuthor("Adrián Cobo");
+		COMMENT.setComment("Test comment");
+		COMMENT.setLikes(10);
+		COMMENT.setPostBlog(POST_BLOG);
+
+		COMMENT2.setId(2);
+		COMMENT2.setAuthor("Adrián Cobo");
+		COMMENT2.setComment("Test comment 2");
+		COMMENT2.setLikes(20);
+		COMMENT2.setPostBlog(POST_BLOG);
+
+		POST_BLOG.setComments(Set.of(COMMENT, COMMENT2));
+
+		COMMENT3.setId(3);
+		COMMENT3.setAuthor("Adrián Cobo");
+		COMMENT3.setComment("Test comment 3");
+		COMMENT3.setLikes(30);
+	}
+
+	@Autowired
+	private QFProcessor<FilterCommentBlogDef, Comments> qfProcessor;
+
+	@Autowired
+	private PostBlogRepository postBlogRepository;
+
+	@Autowired
+	private CommentsRepository commentsRepository;
+
+	@Test
+	@DisplayName("0. Setup")
+	@Order(Ordered.HIGHEST_PRECEDENCE)
+	void setup() {
+
+		assertThat(qfProcessor).isNotNull();
+		assertThat(postBlogRepository).isNotNull();
+		assertThat(commentsRepository).isNotNull();
+
+		assertThat(postBlogRepository.findAll()).isEmpty();
+		assertThat(commentsRepository.findAll()).isEmpty();
+
+		postBlogRepository.save(POST_BLOG);
+		commentsRepository.save(COMMENT);
+		commentsRepository.save(COMMENT2);
+		commentsRepository.save(COMMENT3);
+
+		assertThat(postBlogRepository.findAll()).hasSize(1).containsExactlyInAnyOrder(POST_BLOG);
+		assertThat(commentsRepository.findAll()).hasSize(3).containsExactlyInAnyOrder(COMMENT, COMMENT2, COMMENT3);
+
+	}
+
+	@Test
+	@DisplayName("1. Test sort by author with autoFetch return 1 element (because is Inner JOIN)")
+	@Order(1)
+	void testSortByAuthor() {
+
+		var qf = qfProcessor.newQueryFilter("sort=+blogAuthor", QFParamType.RHS_COLON);
+		assertThat(qf).isNotNull();
+
+		assertThat(qf.isSorted()).isTrue();
+
+		assertThat(qf.isSortedBy("blogAuthor")).isTrue();
+
+		assertThat(qf.getSortFields()).containsExactly(Pair.of("blogAuthor", Sort.Direction.ASC));
+
+		assertThat(qf.getSortFieldWithFullPath()).containsExactly(Pair.of("postBlog.author", Sort.Direction.ASC));
+
+
+		var countQuery = commentsRepository.count(qf);
+		assertThat(countQuery).isEqualTo(2);
+
+	}
+
+	@Test
+	@DisplayName("END. Test by clear BBDD")
+	@Order(Ordered.LOWEST_PRECEDENCE)
+	void clearBBDD() {
+
+		postBlogRepository.deleteAll();
+		assertThat(postBlogRepository.findAll()).isEmpty();
+
+		commentsRepository.deleteAll();
+		assertThat(commentsRepository.findAll()).isEmpty();
+	}
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/AutoFetchSortTest.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/AutoFetchSortTest.java
@@ -341,7 +341,7 @@ class AutoFetchSortTest {
 		assertThat(page0).hasSize(1).containsExactly(POST_EXAMPLE_2);
 		assertThat(page0.getTotalElements()).isEqualTo(2);
 		assertThat(page0.getTotalPages()).isEqualTo(2);
-		assertThat(page0.getNumber()).isEqualTo(0);
+		assertThat(page0.getNumber()).isZero();
 		assertThat(page0.getSize()).isEqualTo(1);
 
 		var page1 = repository.findAll(qf, PageRequest.of(1, 1));

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/OperationAllowedTests.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/OperationAllowedTests.java
@@ -27,7 +27,7 @@ import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class OperationAllowedTests {
+class OperationAllowedTests {
 
 	private static final Set<QFOperationEnum> ALLOWED_OPERATIONS = Set.of(QFOperationEnum.EQUAL,
 			QFOperationEnum.STARTS_WITH, QFOperationEnum.ENDS_WITH, QFOperationEnum.LIKE);
@@ -60,8 +60,9 @@ public class OperationAllowedTests {
 
 		for (QFOperationEnum op : QFOperationEnum.values()) {
 			if (!ALLOWED_OPERATIONS.contains(op)) {
+				String filter = "author=" + op.getValue() + ":a";
 				QFOperationNotAllowed ex = assertThrows(QFOperationNotAllowed.class,
-						() -> qfProcessor.newQueryFilter("author=" + op.getValue() + ":a", QFParamType.RHS_COLON));
+						() -> qfProcessor.newQueryFilter(filter, QFParamType.RHS_COLON));
 				assertThat(ex).isNotNull();
 				assertThat(ex.getMessage()).isNotNull();
 				assertThat(ex.getMessage())

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/OperationAllowedTests.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/OperationAllowedTests.java
@@ -1,0 +1,76 @@
+package io.github.acoboh.query.filter.jpa.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import io.github.acoboh.query.filter.jpa.domain.FilterAllowedOperationsBlogDef;
+import io.github.acoboh.query.filter.jpa.exceptions.QFOperationNotAllowed;
+import io.github.acoboh.query.filter.jpa.model.PostBlog;
+import io.github.acoboh.query.filter.jpa.operations.QFOperationEnum;
+import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
+
+@SpringJUnitWebConfig(SpringIntegrationTestBase.Config.class)
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class OperationAllowedTests {
+
+	private static final Set<QFOperationEnum> ALLOWED_OPERATIONS = Set.of(QFOperationEnum.EQUAL,
+			QFOperationEnum.STARTS_WITH, QFOperationEnum.ENDS_WITH, QFOperationEnum.LIKE);
+
+	@Autowired
+	private QFProcessor<FilterAllowedOperationsBlogDef, PostBlog> qfProcessor;
+
+	@Test
+	@DisplayName("0. Setup")
+	@Order(Ordered.HIGHEST_PRECEDENCE)
+	void setup() {
+		assertThat(qfProcessor).isNotNull();
+	}
+
+	@Test
+	@DisplayName("1. Test by author allowed operations")
+	@Order(1)
+	void testAllowedOperations() {
+
+		for (QFOperationEnum op : ALLOWED_OPERATIONS) {
+			assertThat(qfProcessor.newQueryFilter("author=" + op.getValue() + ":a", QFParamType.RHS_COLON)).isNotNull();
+		}
+
+	}
+
+	@Test
+	@DisplayName("2. Test by author not allowed operations")
+	@Order(2)
+	void testNotAllowed() {
+
+		for (QFOperationEnum op : QFOperationEnum.values()) {
+			if (!ALLOWED_OPERATIONS.contains(op)) {
+				QFOperationNotAllowed ex = assertThrows(QFOperationNotAllowed.class,
+						() -> qfProcessor.newQueryFilter("author=" + op.getValue() + ":a", QFParamType.RHS_COLON));
+				assertThat(ex).isNotNull();
+				assertThat(ex.getMessage()).isNotNull();
+				assertThat(ex.getMessage())
+						.contains("The operation '" + op.getValue() + "' is not allowed for the field 'author'");
+				assertThat(ex.getOperation()).isEqualTo(op.getValue());
+				assertThat(ex.getField()).isEqualTo("author");
+			}
+		}
+
+	}
+
+}

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/errors/TestQFProcessorErrors.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/processor/errors/TestQFProcessorErrors.java
@@ -15,7 +15,10 @@ import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import io.github.acoboh.query.filter.jpa.exceptions.definition.QFDiscriminatorException;
+import io.github.acoboh.query.filter.jpa.exceptions.definition.QueryFilterDefinitionException;
 import io.github.acoboh.query.filter.jpa.filtererrors.discriminator.DiscriminatorFilterErrorDef;
+import io.github.acoboh.query.filter.jpa.filtererrors.discriminator.OperationAllowedError1Def;
+import io.github.acoboh.query.filter.jpa.model.PostBlog;
 import io.github.acoboh.query.filter.jpa.model.discriminators.Topic;
 import io.github.acoboh.query.filter.jpa.processor.QFProcessor;
 import io.github.acoboh.query.filter.jpa.spring.SpringIntegrationTestBase;
@@ -39,5 +42,17 @@ class TestQFProcessorErrors {
 
 		assertThat(ex.getMessage()).isEqualTo(
 				"Entity class 'class io.github.acoboh.query.filter.jpa.model.discriminators.Topic' is not assignable from value class 'class io.github.acoboh.query.filter.jpa.model.PostBlog'");
+	}
+
+	@Test
+	@DisplayName("2. Test QFProcessor QFElement with not allowed operation")
+	void testQFElementNotAllowedOperation() {
+
+		QueryFilterDefinitionException ex = assertThrows(QueryFilterDefinitionException.class, () -> {
+			new QFProcessor<>(OperationAllowedError1Def.class, PostBlog.class, appContext);
+		});
+
+		assertThat(ex.getMessage()).isEqualTo(
+				"Allowed operations [ENDS_WITH] not valid for class int on field likes of filter class io.github.acoboh.query.filter.jpa.filtererrors.discriminator.OperationAllowedError1Def");
 	}
 }

--- a/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/repositories/CommentsRepository.java
+++ b/query-filter-jpa-3/src/test/java/io/github/acoboh/query/filter/jpa/repositories/CommentsRepository.java
@@ -1,0 +1,9 @@
+package io.github.acoboh.query.filter.jpa.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import io.github.acoboh.query.filter.jpa.model.Comments;
+
+public interface CommentsRepository extends JpaSpecificationExecutor<Comments>, JpaRepository<Comments, Integer> {
+}

--- a/query-filter-jpa-openapi-3/src/main/java/io/github/acoboh/query/filter/jpa/openapi/config/OpenApiCustomiserImpl.java
+++ b/query-filter-jpa-openapi-3/src/main/java/io/github/acoboh/query/filter/jpa/openapi/config/OpenApiCustomiserImpl.java
@@ -11,7 +11,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -180,8 +179,7 @@ class OpenApiCustomiserImpl implements OpenApiCustomizer {
 			builder.append("<p><b>").append(def.getFilterName()).append("</b>:");
 
 			if (def instanceof QFDefinitionElement defElement) {
-				Set<QFOperationEnum> qfOperations = QFOperationEnum
-						.getOperationsOfClass(defElement.getFirstFinalClass(), defElement.isArrayTyped());
+				Set<QFOperationEnum> qfOperations = defElement.getRealAllowedOperations();
 
 				if (!qfOperations.isEmpty()) {
 					builder.append(" Operations: [<i>");
@@ -198,7 +196,7 @@ class OpenApiCustomiserImpl implements OpenApiCustomizer {
 
 			if (def instanceof QFDefinitionDiscriminator qdefDiscriminator) {
 				builder.append(" Operations: [<i>");
-				String operationsAvailable = Stream.of(QFOperationDiscriminatorEnum.values())
+				String operationsAvailable = qdefDiscriminator.getRealAllowedOperations().stream()
 						.map(QFOperationDiscriminatorEnum::getOperation).collect(Collectors.joining(","));
 				builder.append(operationsAvailable).append("</i>]");
 
@@ -206,10 +204,10 @@ class OpenApiCustomiserImpl implements OpenApiCustomizer {
 				String values = Arrays.stream(qdefDiscriminator.getDiscriminatorAnnotation().value())
 						.map(QFDiscriminator.Value::name).collect(Collectors.joining(","));
 				builder.append(values).append("]");
-			} else if (def instanceof QFDefinitionJson) {
+			} else if (def instanceof QFDefinitionJson qdefJson) {
 				builder.append(" <i>(JSON element)</i> Operations: [<i>");
 
-				String operationsAvailable = Stream.of(QFOperationJsonEnum.values())
+				String operationsAvailable = qdefJson.getRealAllowedOperations().stream()
 						.map(QFOperationJsonEnum::getOperation).collect(Collectors.joining(","));
 				builder.append(operationsAvailable).append("</i>]");
 			}
@@ -223,7 +221,6 @@ class OpenApiCustomiserImpl implements OpenApiCustomizer {
 	private Operation getOperation(PathItem item, RequestMethod method) {
 
 		return switch (method) {
-
 			case DELETE -> item.getDelete();
 			case HEAD -> item.getHead();
 			case OPTIONS -> item.getOptions();


### PR DESCRIPTION
Adds the ability to restrict allowed operations on filter fields via annotations. Introduces QFOperationNotAllowed exception and accompanying error message. Adds a configuration option to extend error messages in the exception advisor. Fixes an issue where auto-fetch sort operations were not working correctly with inner joins.