### PR TITLE
Removes Reflections library

### DIFF
--- a/query-filter-jpa-3/pom.xml
+++ b/query-filter-jpa-3/pom.xml
@@ -16,8 +16,6 @@
     <description>Query filter JPA for Spring Boot 3.X</description>
 
     <properties>
-        <!-- Reflections -->
-        <reflections.version>0.10.2</reflections.version>
         <!-- Hypersistance tests -->
         <hypersistance.version>3.9.10</hypersistance.version>
     </properties>
@@ -99,13 +97,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-        </dependency>
-
-        <!-- Reflections -->
-        <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>${reflections.version}</version>
         </dependency>
 
         <dependency>

--- a/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/hints/HintsRegistrarDef.java
+++ b/query-filter-jpa-3/src/main/java/io/github/acoboh/query/filter/jpa/hints/HintsRegistrarDef.java
@@ -2,17 +2,21 @@ package io.github.acoboh.query.filter.jpa.hints;
 
 import java.util.Set;
 
-import org.reflections.Reflections;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.lang.NonNull;
 
+import io.github.acoboh.query.filter.jpa.annotations.EnableQueryFilter;
 import io.github.acoboh.query.filter.jpa.annotations.QFDefinitionClass;
 
 /**
@@ -38,22 +42,13 @@ public class HintsRegistrarDef {
 				MemberCategory.DECLARED_FIELDS, MemberCategory.PUBLIC_CLASSES, MemberCategory.DECLARED_CLASSES};
 
 		@Override
-		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+		public void registerHints(@NonNull RuntimeHints hints, ClassLoader classLoader) {
+			registerManualHints(hints);
+			processQFClasses(classLoader, hints.reflection());
+		}
 
+		private void registerManualHints(RuntimeHints hints) {
 			var rh = hints.reflection();
-
-			Reflections reflect = new Reflections(
-					new ConfigurationBuilder().setUrls(ClasspathHelper.forJavaClassPath()));
-
-			Set<Class<?>> annotatedClasses = reflect.getTypesAnnotatedWith(QFDefinitionClass.class);
-
-			LOGGER.info("Found {} classes annotated with QFDefinitionClass", annotatedClasses.size());
-			for (Class<?> annotatedClass : annotatedClasses) {
-				LOGGER.info("Processing class {}", annotatedClass.getName());
-				rh.registerType(annotatedClass, memberCategories);
-
-			}
-
 			// Add for security
 			rh.registerType(jakarta.servlet.http.HttpServletRequest.class, MemberCategory.values());
 			hints.proxies().registerJdkProxy(jakarta.servlet.http.HttpServletRequest.class);
@@ -62,7 +57,62 @@ public class HintsRegistrarDef {
 			hints.proxies().registerJdkProxy(jakarta.servlet.http.HttpServletResponse.class);
 
 			hints.resources().registerPattern("queryfilter-messages/messages_*.properties");
+		}
 
+		private void processQFClasses(ClassLoader classLoader, ReflectionHints rh) {
+			// Create a component provider that includes non-infrastructure classes
+			var scanner = new ClassPathScanningCandidateComponentProvider(false);
+
+			// Add filter to detect classes annotated with EnableQueryFilter
+			scanner.addIncludeFilter(new AnnotationTypeFilter(EnableQueryFilter.class));
+			scanner.setResourceLoader(new PathMatchingResourcePatternResolver(classLoader));
+
+			// Find candidate components
+			Set<BeanDefinition> candidates = scanner.findCandidateComponents("");
+
+			LOGGER.info("Found {} classes annotated with EnableQueryFilter", candidates.size());
+
+			for (BeanDefinition beanDefinition : candidates) {
+				try {
+					Class<?> clazz = Class.forName(beanDefinition.getBeanClassName(), false, classLoader);
+					LOGGER.info("Processing EnableQueryFilter annotated class {}", clazz.getName());
+					EnableQueryFilter qfAnnotation = clazz.getAnnotation(EnableQueryFilter.class);
+					if (qfAnnotation == null) {
+						continue;
+					}
+					for (var pack : qfAnnotation.basePackages()) {
+						LOGGER.info("Processing package from annotation EnableQueryFilter {}", pack);
+						registerClassesInPackage(pack, rh, classLoader);
+					}
+
+					for (var packClass : qfAnnotation.basePackageClasses()) {
+						LOGGER.info("Processing package class from annotation EnableQueryFilter {}",
+								packClass.getName());
+						registerClassesInPackage(packClass.getPackageName(), rh, classLoader);
+					}
+
+				} catch (ClassNotFoundException e) {
+					LOGGER.error("Could not find class {}", beanDefinition.getBeanClassName(), e);
+				}
+			}
+		}
+
+		private void registerClassesInPackage(String basePackage, ReflectionHints rh, ClassLoader classLoader) {
+			var scanner = new ClassPathScanningCandidateComponentProvider(false);
+			scanner.addIncludeFilter(new AnnotationTypeFilter(QFDefinitionClass.class));
+			scanner.setResourceLoader(new PathMatchingResourcePatternResolver(classLoader));
+
+			Set<BeanDefinition> candidates = scanner.findCandidateComponents(basePackage);
+
+			for (BeanDefinition beanDefinition : candidates) {
+				try {
+					Class<?> clazz = Class.forName(beanDefinition.getBeanClassName(), false, classLoader);
+					LOGGER.info("Processing class {}", clazz.getName());
+					rh.registerType(clazz, memberCategories);
+				} catch (ClassNotFoundException e) {
+					LOGGER.error("Could not find class {}", beanDefinition.getBeanClassName(), e);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Refactors HintsRegistrarDef to remove the Reflections library.

The previous implementation used Reflections to discover classes annotated with QFDefinitionClass. This approach has been replaced with Spring's ClassPathScanningCandidateComponentProvider for better integration with Spring's component scanning mechanism and to avoid the overhead and potential issues associated with Reflections.